### PR TITLE
Ensure babel.parse does not use top level babel config.

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -107,9 +107,10 @@ export default function makePlugin<O>(
         precompileResultString = precompile(template, options);
       }
 
-      let precompileResultAST = babel.parse(
-        `var precompileResult = ${precompileResultString};`
-      ) as t.File;
+      let precompileResultAST = babel.parse(`var precompileResult = ${precompileResultString};`, {
+        babelrc: false,
+        configFile: false,
+      }) as t.File;
 
       let templateExpression = (precompileResultAST.program.body[0] as t.VariableDeclaration)
         .declarations[0].init as t.Expression;


### PR DESCRIPTION
Without this, using `babel.config.js` (as introduced in ember-cli-babel >= 7.24.0) for babel configuration with certain presets (e.g.  `@babel/preset-typescript`) throws an error.

Same fix as https://github.com/ember-cli/babel-plugin-htmlbars-inline-precompile/pull/477
