### PR TITLE
Fix side effecting ember cli htmlbars import

### DIFF
--- a/__tests__/tests.ts
+++ b/__tests__/tests.ts
@@ -303,6 +303,26 @@ describe('htmlbars-inline-precompile', function () {
     `);
   });
 
+  it('removes no-op imports from ember-cli-htmlbars', function () {
+    plugins = [
+      [
+        HTMLBarsInlinePrecompile,
+        buildOptions({
+          enableLegacyModules: ['ember-cli-htmlbars'],
+        }),
+      ],
+    ];
+
+    // This occurs with rollup builds when it does is import hoisting
+    // (which is done to improve overall speed of loading module graphs)
+    // Since this package shouldn't exist at runtime, it must be removed entirely
+    let transformed = transform("import 'ember-cli-htmlbars';\nlet hello = `world`;");
+
+    expect(transformed).toMatchInlineSnapshot(`
+      let hello = \`world\`;
+    `);
+  });
+
   it('leaves tagged template expressions alone when ember-cli-htmlbars is disabled', function () {
     let transformed = transform(
       "import { hbs as baz } from 'ember-cli-htmlbars';\nvar compiled = baz`hello`;"

--- a/__tests__/tests.ts
+++ b/__tests__/tests.ts
@@ -318,9 +318,7 @@ describe('htmlbars-inline-precompile', function () {
     // Since this package shouldn't exist at runtime, it must be removed entirely
     let transformed = transform("import 'ember-cli-htmlbars';\nlet hello = `world`;");
 
-    expect(transformed).toMatchInlineSnapshot(`
-      let hello = \`world\`;
-    `);
+    expect(transformed).toMatchInlineSnapshot(`"let hello = \`world\`;"`);
   });
 
   it('leaves tagged template expressions alone when ember-cli-htmlbars is disabled', function () {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -150,6 +150,23 @@ export default function makePlugin<O>(
           },
         },
 
+        ImportDeclaration(path: NodePath<t.ImportDeclaration>, state: State) {
+          /**
+           * These modules don't actually exist, so if a build tool leaves them in
+           * (without specifiers), we need to remove those (otherwise the app/library
+           * author will run in to a runtime error due to the module not existing).
+           */
+          if (path.node.specifiers.length > 0) return;
+
+          let importPath = path.node.source.value;
+
+          for (let module of configuredModules(state)) {
+            if (importPath === module.moduleName) {
+              state.util.removeAllImports(importPath);
+            }
+          }
+        },
+
         TaggedTemplateExpression(path: NodePath<t.TaggedTemplateExpression>, state: State) {
           let tagPath = path.get('tag');
 


### PR DESCRIPTION
rollup & co will try to optimize our v2 addons for runtime by hoisting the ember-cli-htmlbars to the toppest entry module.

during an app's build time, we need to remove that.