### PR TITLE
allow direct access to browser and node implementations

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     ".": {
       "browser": "./src/plugin.js",
       "default": "./src/node-main.js"
-    }
+    },
+    "./browser": "./src/plugin.js",
+    "./node": "./src/node-main.js"
   },
   "files": [
     "src/**/*.js",


### PR DESCRIPTION
By default, consumers will get either the node or browser implementation automatically based on their environment.

Since these implementations support slightly different options, consumers that want to be portable themselves may want to pick one implementation (probably the browser one, since it is the more portable) and stick to it, regardless of their own environment.

This change enables that by allowing direct imports of `babel-plugin-ember-template-compilation/browser` and `babel-plugin-ember-template-compilation/node`, both of which bypass the automatic environment switching.