### PR TITLE
Handle repeated `bindExpression` and `bindImport` calls

### DIFF
--- a/__tests__/tests.ts
+++ b/__tests__/tests.ts
@@ -751,6 +751,22 @@ describe('htmlbars-inline-precompile', function () {
       expect(transformed).toContain(`let two = 1 + 1`);
     });
 
+    it('does not smash other previously-bound expressions with new ones', () => {
+      precompile = runASTTransform(compiler, expressionTransform);
+
+      let transformed = transform(stripIndent`
+        import { precompileTemplate } from '@ember/template-compilation';
+        export default function() {
+          const template = precompileTemplate('{{onePlusOne}}{{onePlusOne}}');
+        }
+      `);
+
+      expect(transformed).toContain(`{{two}}{{two0}}`);
+      expect(transformed).toContain(`locals: [two, two0]`);
+      expect(transformed).toContain(`let two = 1 + 1`);
+      expect(transformed).toContain(`let two0 = 1 + 1`);
+    });
+
     it('can bind expressions that need imports', function () {
       let nowTransform: ASTPluginBuilder<WithJSUtils<ASTPluginEnvironment>> = (env) => {
         return {

--- a/src/js-utils.ts
+++ b/src/js-utils.ts
@@ -100,8 +100,19 @@ export class JSUtils {
       opts?.nameHint
     );
 
-    let identifier = unusedNameLike(importedIdentifier.name, (candidate) =>
-      astNodeHasBinding(target, candidate)
+    // If we're already referencing the imported name from the outer scope and
+    // it's not shadowed at our target location in the template, we can reuse
+    // the existing import.
+    if (
+      this.#locals.includes(importedIdentifier.name) &&
+      !astNodeHasBinding(target, importedIdentifier.name)
+    ) {
+      return importedIdentifier.name;
+    }
+
+    let identifier = unusedNameLike(
+      importedIdentifier.name,
+      (candidate) => this.#locals.includes(candidate) || astNodeHasBinding(target, candidate)
     );
     if (identifier !== importedIdentifier.name) {
       // The importedIdentifier that we have in Javascript is not usable within

--- a/src/js-utils.ts
+++ b/src/js-utils.ts
@@ -50,7 +50,9 @@ export class JSUtils {
     let name = unusedNameLike(
       opts?.nameHint ?? 'a',
       (candidate) =>
-        this.#template.scope.hasBinding(candidate) || astNodeHasBinding(target, candidate)
+        this.#template.scope.hasBinding(candidate) ||
+        this.#locals.includes(candidate) ||
+        astNodeHasBinding(target, candidate)
     );
     let t = this.#babel.types;
     this.#emitStatement(


### PR DESCRIPTION
@ef4 I've been spiking out a version of `ember-css-modules` that uses the alpha `JSUtils` functionality to transform `local-class` attributes into import references and found that repeated calls to `bindExpression` and `bindImport` can result in erroneous or redundant code.

I've taken a pass at handling these cases more gracefully, but I'm not 100% sure of my mental model for the relationship between our `locals` array and what's ultimately produced as `scope`, so if I've got a bad assumption here I'm happy to make changes.

### `bindExpression`

If I call `bindExpression('2 + 2', target, { nameHint: 'two' })` twice in the same template, this would wind up emitting code like this, which throws a `SyntaxError` due to the duplicate declaration:

```ts
let two = 1 + 1;
let two = 1 + 1;
```

This PR updates `bindExpression` to ensure it accounts for locals we introduced ourselves when looking for a fresh name.

### `bindImport`

If I call `bindImport('my-library', 'default', target, { nameHint: 'two' })` twice in the same template, the code produced isn't incorrect, but it's a bit weird. In the tests, you'll see output like this, with `two` appearing twice in `locals`:

```ts
import { createTemplateFactory } from "@ember/template-factory";
import two from "my-library";
export default function () {
  const template = createTemplateFactory(
  /*
    {{onePlusOne}}{{onePlusOne}}
  */
  {
    transformedHBS: `{{two}}{{two}}`,
    locals: [two, two]
  });
}
```

This PR updates `bindImport` to reuse the existing identifier if possible, ensuring that we still alias it if necessary due to other elements in template scope.