### PR TITLE
Use the relative path for precompiled moduleName

### DIFF
--- a/__tests__/tests.ts
+++ b/__tests__/tests.ts
@@ -8,6 +8,7 @@ import { stripIndent } from 'common-tags';
 import { EmberTemplateCompiler } from '../src/ember-template-compiler';
 import sinon from 'sinon';
 import { ExtendedPluginBuilder } from '../src/js-utils';
+import assert from 'assert';
 import 'code-equality-assertions/jest';
 
 describe('htmlbars-inline-precompile', function () {
@@ -18,7 +19,8 @@ describe('htmlbars-inline-precompile', function () {
   function transform(code: string) {
     let x = babel
       .transform(code, {
-        filename: 'foo-bar.js',
+        filename: '/my-computer/workspace/my-package/src/my-file.js',
+        cwd: '/my-computer/workspace/my-package/',
         plugins,
       })!
       .code!.trim();
@@ -80,6 +82,17 @@ describe('htmlbars-inline-precompile', function () {
     );
 
     expect(spy.firstCall.lastArg).toHaveProperty('contents', source);
+  });
+
+  it('moduleName is defined and is a relative path', function () {
+    let source = 'hello';
+
+    const result = transform(
+      `import { precompileTemplate } from '@ember/template-compilation';\nvar compiled = precompileTemplate('${source}');`
+    );
+    const match = result.match(/"moduleName": ?"(.+)"/);
+    assert(match);
+    expect(match[1]).toEqual('src/my-file.js');
   });
 
   it('uses the user provided isProduction option if present', function () {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -6,6 +6,7 @@ import { ExpressionParser } from './expression-parser';
 import { JSUtils, ExtendedPluginBuilder } from './js-utils';
 import type { EmberTemplateCompiler, PreprocessOptions } from './ember-template-compiler';
 import { LegacyModuleName } from './public-types';
+import { relative } from 'path';
 
 export * from './public-types';
 
@@ -96,6 +97,8 @@ interface State<EnvSpecificOptions> {
   program: NodePath<t.Program>;
   lastInsertedPath: NodePath<t.Statement> | undefined;
   filename: string;
+  file: Babel.BabelFile;
+  cwd: string;
 }
 
 export function makePlugin<EnvSpecificOptions>(loadOptions: (opts: EnvSpecificOptions) => Options) {
@@ -277,6 +280,7 @@ function buildPrecompileOptions<EnvSpecificOptions>(
   }
   let jsutils = new JSUtils(babel, state, target, userTypedOptions.locals as string[], state.util);
   let meta = Object.assign({ jsutils }, userTypedOptions?.meta);
+
   return Object.assign(
     {
       contents: template,
@@ -285,7 +289,7 @@ function buildPrecompileOptions<EnvSpecificOptions>(
       // TODO: embroider's template-compiler allows this to be overriden to get
       // backward-compatible module names that don't match the real name of the
       // on-disk file. What's our plan for migrating people away from that?
-      moduleName: state.filename,
+      moduleName: relative(state.cwd, state.filename),
 
       // This is here so it's *always* the real filename. Historically, there is
       // also `moduleName` but that did not match the real on-disk filename, it


### PR DESCRIPTION
While testing out https://github.com/ember-cli/ember-cli-htmlbars/pull/762, I realized that we probably don't want the precompiled template `moduleName` to be an absolute path, as that would be exposing production box internals. It also doesn't match the previous behavior of older templates where `moduleName` is relative.

This change constructs the `moduleName` using the `path.relative` of the babel [`cwd`](https://babeljs.io/docs/en/options#cwd) and [`filename`](https://babeljs.io/docs/en/options#filename) options, instead of just `filename`. I tested this change out locally in an ember app. Instead of using `cwd` and `filename` with `path.relative`, we could also use `state.file.opts.sourceFileName`, which works here when I run locally, but not sure it would work universally. In theory, we could use [`filenameRelative`](https://babeljs.io/docs/en/options#filenamerelative), but anecdotally that option is not available when I build my own app locally, so it may be a new option.

Without the source code change, verified tests fail:

![Screenshot 2023-01-17 at 5 07 45 PM](https://user-images.githubusercontent.com/597574/213058837-accfc973-6933-474e-b911-a428acc8c126.png)
