### PR TITLE
PrecompileTemplate with scope that has properties with different key and value

### DIFF
--- a/__tests__/tests.ts
+++ b/__tests__/tests.ts
@@ -1194,6 +1194,37 @@ describe('htmlbars-inline-precompile', function () {
       `);
     });
 
+    it('adds new locals to preexisting renamed scope', function () {
+      plugins = [
+        [
+          HTMLBarsInlinePrecompile,
+          { compiler, targetFormat: 'hbs', transforms: [expressionTransform] },
+        ],
+      ];
+
+      let transformed = transform(stripIndent`
+        import { precompileTemplate } from '@ember/template-compilation';
+        import Message$ from 'message';
+        const template = precompileTemplate('<Message @text={{onePlusOne}} />', {
+          scope: () => ({
+            Message: Message$
+          })
+        });
+      `);
+
+      expect(transformed).toEqualCode(`
+        import { precompileTemplate } from '@ember/template-compilation';
+        import Message$ from 'message';
+        let two = 1 + 1;
+        const template = precompileTemplate("<Message @text={{two}} />", {
+          scope: () => ({
+            Message: Message$,
+            two
+          })
+        });
+      `);
+    });
+
     it('switches from legacy callExpressions to precompileTemplate when needed to support scope', function () {
       plugins = [
         [

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -7,6 +7,7 @@ import { ExpressionParser } from './expression-parser';
 import { JSUtils, ExtendedPluginBuilder } from './js-utils';
 import type { EmberTemplateCompiler, PreprocessOptions } from './ember-template-compiler';
 import { LegacyModuleName } from './public-types';
+import { ScopeLocals } from './scope-locals';
 
 export * from './public-types';
 
@@ -266,73 +267,71 @@ function runtimeErrorIIFE(babel: typeof Babel, replacements: { ERROR_MESSAGE: st
   return statement.expression;
 }
 
+function buildScopeLocals(userTypedOptions: Record<string, unknown>): ScopeLocals {
+  if (userTypedOptions.scope) {
+    return userTypedOptions.scope as ScopeLocals;
+  } else {
+    return new ScopeLocals();
+  }
+}
+
 function buildPrecompileOptions<EnvSpecificOptions>(
   babel: typeof Babel,
   target: NodePath<t.Expression>,
   state: State<EnvSpecificOptions>,
   template: string,
-  userTypedOptions: Record<string, unknown>
+  userTypedOptions: Record<string, unknown>,
+  scope: ScopeLocals
 ): PreprocessOptions & Record<string, unknown> {
-  if (!userTypedOptions.locals) {
-    userTypedOptions.locals = [];
-  }
-  let jsutils = new JSUtils(babel, state, target, userTypedOptions.locals as string[], state.util);
+  let jsutils = new JSUtils(babel, state, target, scope, state.util);
   let meta = Object.assign({ jsutils }, userTypedOptions?.meta);
-  return Object.assign(
-    {
-      contents: template,
-      meta,
 
-      // TODO: embroider's template-compiler allows this to be overriden to get
-      // backward-compatible module names that don't match the real name of the
-      // on-disk file. What's our plan for migrating people away from that?
-      moduleName: state.filename,
+  let output: PreprocessOptions & Record<string, unknown> = {
+    contents: template,
+    meta,
 
-      // This is here so it's *always* the real filename. Historically, there is
-      // also `moduleName` but that did not match the real on-disk filename, it
-      // was the notional runtime module name from classic ember builds.
-      filename: state.filename,
+    // TODO: embroider's template-compiler allows this to be overriden to get
+    // backward-compatible module names that don't match the real name of the
+    // on-disk file. What's our plan for migrating people away from that?
+    moduleName: state.filename,
 
-      plugins: {
-        ast: state.normalizedOpts.transforms,
-      },
+    // This is here so it's *always* the real filename. Historically, there is
+    // also `moduleName` but that did not match the real on-disk filename, it
+    // was the notional runtime module name from classic ember builds.
+    filename: state.filename,
+
+    plugins: {
+      ast: state.normalizedOpts.transforms,
     },
-    userTypedOptions
-  );
+  };
+
+  for (let [key, value] of Object.entries(userTypedOptions)) {
+    if (key !== 'scope') {
+      // `scope` in the user-facing API becomes `locals` in the low-level
+      // ember-template-compiler API
+      output[key] = value;
+    }
+  }
+
+  output.locals = scope.locals;
+  return output;
 }
 
 // if scope has different keys and values, this function will remap the keys to the values
 // you can see an example of this in the test "correctly handles scope if it contains keys and values"
-function remapIdentifiers(ast: Babel.types.File, localsWithNames?: { [key: string]: string }) {
-  if (
-    !localsWithNames ||
-    Object.keys(localsWithNames).length === 0 ||
-    Object.keys(localsWithNames).every((key) => key === localsWithNames[key])
-  ) {
+function remapIdentifiers(ast: Babel.types.File, babel: typeof Babel, scopeLocals: ScopeLocals) {
+  if (!scopeLocals.needsRemapping()) {
     // do nothing if all keys are the same as their values
     return;
   }
 
-  let visitor = {
-    ObjectProperty(path: NodePath<t.ObjectProperty>) {
-      if (
-        path.node.key.type === 'StringLiteral' &&
-        path.node.key.value === 'scope' &&
-        path.node.value.type === 'ArrowFunctionExpression' &&
-        path.node.value.body.type === 'ArrayExpression'
-      ) {
-        for (let element of path.node.value.body.elements) {
-          if (element?.type === 'Identifier') {
-            const replacement = localsWithNames[element.name];
-            if (replacement) {
-              element.name = replacement;
-            }
-          }
-        }
+  traverse(ast, {
+    Identifier(path: NodePath<t.Identifier>) {
+      if (scopeLocals.has(path.node.name)) {
+        path.replaceWith(babel.types.identifier(scopeLocals.get(path.node.name)));
       }
     },
-  };
-  traverse(ast, visitor);
+  });
 }
 
 function insertCompiledTemplate<EnvSpecificOptions>(
@@ -343,7 +342,15 @@ function insertCompiledTemplate<EnvSpecificOptions>(
   userTypedOptions: Record<string, unknown>
 ) {
   let t = babel.types;
-  let options = buildPrecompileOptions(babel, target, state, template, userTypedOptions);
+  let scopeLocals = buildScopeLocals(userTypedOptions);
+  let options = buildPrecompileOptions(
+    babel,
+    target,
+    state,
+    template,
+    userTypedOptions,
+    scopeLocals
+  );
 
   let precompileResultString: string;
 
@@ -363,8 +370,7 @@ function insertCompiledTemplate<EnvSpecificOptions>(
     configFile: false,
   }) as t.File;
 
-  const localsWithNames = <{ [key: string]: string } | undefined>userTypedOptions.localsWithNames;
-  remapIdentifiers(precompileResultAST, localsWithNames);
+  remapIdentifiers(precompileResultAST, babel, scopeLocals);
 
   let templateExpression = (precompileResultAST.program.body[0] as t.VariableDeclaration)
     .declarations[0].init as t.Expression;
@@ -393,27 +399,35 @@ function insertTransformedTemplate<EnvSpecificOptions>(
   formatOptions: ModuleConfig
 ) {
   let t = babel.types;
-  let options = buildPrecompileOptions(babel, target, state, template, userTypedOptions);
+  let scopeLocals = buildScopeLocals(userTypedOptions);
+  let options = buildPrecompileOptions(
+    babel,
+    target,
+    state,
+    template,
+    userTypedOptions,
+    scopeLocals
+  );
   let ast = state.normalizedOpts.compiler._preprocess(template, { ...options, mode: 'codemod' });
   let transformed = state.normalizedOpts.compiler._print(ast);
   if (target.isCallExpression()) {
     (target.get('arguments.0') as NodePath<t.Node>).replaceWith(t.stringLiteral(transformed));
-    if (options.locals && options.locals.length > 0) {
+    if (!scopeLocals.isEmpty()) {
       if (!formatOptions.enableScope) {
         maybePruneImport(state.util, target.get('callee'));
         target.set('callee', precompileTemplate(state.util, target));
       }
-      updateScope(babel, target, options.locals);
+      updateScope(babel, target, scopeLocals);
     }
   } else {
-    if (options.locals && options.locals.length > 0) {
+    if (!scopeLocals.isEmpty()) {
       // need to add scope, so need to replace the backticks form with a call
       // expression to precompileTemplate
       maybePruneImport(state.util, target.get('tag'));
       let newCall = target.replaceWith(
         t.callExpression(precompileTemplate(state.util, target), [t.stringLiteral(transformed)])
       )[0];
-      updateScope(babel, newCall, options.locals);
+      updateScope(babel, newCall, scopeLocals);
     } else {
       (target.get('quasi').get('quasis.0') as NodePath<t.TemplateElement>).replaceWith(
         t.templateElement({ raw: transformed })
@@ -431,16 +445,20 @@ function templateFactoryConfig(opts: Required<Options>) {
     : { exportName, moduleName };
 }
 
-function buildScope(babel: typeof Babel, locals: string[]) {
+function buildScope(babel: typeof Babel, locals: ScopeLocals) {
   let t = babel.types;
   return t.arrowFunctionExpression(
     [],
     t.objectExpression(
-      locals.map((name) => t.objectProperty(t.identifier(name), t.identifier(name), false, true))
+      locals
+        .entries()
+        .map(([name, identifier]) =>
+          t.objectProperty(t.identifier(name), t.identifier(identifier), false, true)
+        )
     )
   );
 }
-function updateScope(babel: typeof Babel, target: NodePath<t.CallExpression>, locals: string[]) {
+function updateScope(babel: typeof Babel, target: NodePath<t.CallExpression>, locals: ScopeLocals) {
   let t = babel.types;
   let secondArg = target.get('arguments.1') as NodePath<t.ObjectExpression> | undefined;
   if (secondArg) {

--- a/src/scope-locals.ts
+++ b/src/scope-locals.ts
@@ -1,0 +1,41 @@
+/*
+  This class exists because:
+   - before template compilation starts, we need to pass a `locals` array to
+     ember-template-compiler
+   - the JSUtils API can mutate the scope during template compilation
+   - those scope mutations need to update both the original `locals` array and
+     our own name mapping, keeping them in sync.
+*/
+export class ScopeLocals {
+  #mapping: Record<string, string> = {};
+  #locals: string[] = [];
+
+  get locals() {
+    return this.#locals;
+  }
+
+  has(key: string): boolean {
+    return key in this.#mapping;
+  }
+
+  get(key: string): string {
+    return this.#mapping[key];
+  }
+
+  isEmpty(): boolean {
+    return this.#locals.length === 0;
+  }
+
+  needsRemapping(): boolean {
+    return Object.entries(this.#mapping).some(([k, v]) => k !== v);
+  }
+
+  entries() {
+    return Object.entries(this.#mapping);
+  }
+
+  add(key: string, value?: string) {
+    this.#mapping[key] = value ?? key;
+    this.#locals.push(key);
+  }
+}


### PR DESCRIPTION
## Background

This PR solves a bug in `precompileTemplate` scope. `precompileTemplate` expects that the scope is a function that returns an object with a few properties where keys and values are equal, as in the following example.

```js
import RootSelect from '../different/select.js';
import Select from '../select.js';

precompileTemplate(`
    <RootSelect/>
    <Select/>
    <button {{on "click" this.toogleClicked}}>
      {{#if this.isClicked}}
        Clicked
      {{else}}
        Not clicked
      {{/if}}
    </button>
  `, {
  strictMode: true,
  scope: () => ({
    RootSelect
    Select,
    on
  });
```

But when the project is built with the rollup, imports can be renamed. For example, `Select` can be renamed to `Select$1`, as shown in the following example.

```js
import Select from '../different/select.js';
import Select$1 from '../select.js';

precompileTemplate(`
    <RootSelect/>
    <Select/>
    <button {{on "click" this.toogleClicked}}>
      {{#if this.isClicked}}
        Clicked
      {{else}}
        Not clicked
      {{/if}}
    </button>
  `, {
  strictMode: true,
  scope: () => ({
    RootSelect: Select
    Select: Select$1,
    on
  });
```

From a javascript point of view, everything is correct, and both examples are equivalent. But the second example will fail with an error.

[I have created a simple example where you can see how an import is renamed by rollup](https://github.com/candunaj/template-precompile-scope) and then there is a [problem](https://github.com/candunaj/template-precompile-scope)

## Solution
When a GJS component is built in V2 addon, there is precompileTemplate function in the file in the dist dir. Imported components used in scope can be renamed by Rollup and then properties have different keys and values as shown below:
```js
import Select from '../different/select.js';
import Select$1 from '../select.js';

precompileTemplate(`
    <RootSelect/>
    <Select/>
    <button {{on "click" this.toogleClicked}}>
      {{#if this.isClicked}}
        Clicked
      {{else}}
        Not clicked
      {{/if}}
    </button>
  `, {
  strictMode: true,
  scope: () => ({
    RootSelect: Select,
    Select: Select$1,
    on
  })
```

When the application is built, the ember-auto-import loads V2 addons with babel-plugin-ember-template-compilation and replaces the precompileTemplate with _createTemplateFactory as shown below:

```js
import Select from '../different/select.js';
import Select$1 from '../select.js';

_createTemplateFactory({
      "id":"4QKqJqnE",
      "block":"[[[1,\\"\\\\n    \\"],[8,[32,0],null,null,null],[1,\\"\\\\n    \\"],[8,[32,1],null,null,null],[1,\\"\\\\n    \\"],[11,\\"button\\"],[4,    [32,2],[\\"click\\",[30,0,[\\"toogleClicked\\"]]],null],[12],[1,\\"\\\\n\\"],[41,[30,0,[\\"isClicked\\"]],[[[1,\\"        Clicked\\\\n\\"]],[]],[[[1,\\"        Not clicked\\\\n\\"]],[]]],[1,\\"    \\"],[13],[1,\\"\\\\n  \\"]],[],false,[\\"if\\"]]",
      "moduleName":"(unknown template module)",
      "scope":()=>[RootSelect,Select,on],
      "isStrictMode":true
})
```

The problem is that the scope arrow function returns the original names of the properties. It can be solved by wrapping glimmer wire format in a closure function shown below:

```js
import Select from '../different/select.js';
import Select$1 from '../select.js';

_createTemplateFactory(
    ((RootSelect, Select, on)=>
    ({
      "id":"4QKqJqnE",
      "block":"[...]",
      "moduleName":"(unknown template module)",
      "scope":()=>[RootSelect,Select,on],
      "isStrictMode":true
    }))(Select, Select$1, on)
)
```
