### PR TITLE
Replace Identifier only if key and value are different in the scope

### DIFF
--- a/__tests__/tests.ts
+++ b/__tests__/tests.ts
@@ -1205,8 +1205,10 @@ describe('htmlbars-inline-precompile', function () {
       let transformed = transform(stripIndent`
         import { precompileTemplate } from '@ember/template-compilation';
         import Message$ from 'message';
-        const template = precompileTemplate('<Message @text={{onePlusOne}} />', {
+        import Label from 'label';
+        const template = precompileTemplate('<Label /><Message @text={{onePlusOne}} />', {
           scope: () => ({
+            Label,
             Message: Message$
           })
         });
@@ -1215,9 +1217,11 @@ describe('htmlbars-inline-precompile', function () {
       expect(transformed).toEqualCode(`
         import { precompileTemplate } from '@ember/template-compilation';
         import Message$ from 'message';
+        import Label from 'label';
         let two = 1 + 1;
-        const template = precompileTemplate("<Message @text={{two}} />", {
+        const template = precompileTemplate("<Label /><Message @text={{two}} />", {
           scope: () => ({
+            Label,
             Message: Message$,
             two
           })
@@ -1401,9 +1405,12 @@ describe('htmlbars-inline-precompile', function () {
     });
 
     it('correctly handles scope if it contains keys and values', function () {
-      let transformed = transform(
-        "import bar from 'bar';\nimport { precompileTemplate } from '@ember/template-compilation';\nvar compiled = precompileTemplate('<Foo />', { scope: () => ({ Foo: bar }) });"
-      );
+      let transformed = transform(`
+        import bar from 'bar';
+        import MyButton from 'my-button';
+        import { precompileTemplate } from '@ember/template-compilation';
+        var compiled = precompileTemplate('<Foo /><MyButton />', { scope: () => ({ Foo: bar, MyButton}) });
+      `);
 
       transformed = transformed.replace(/"moduleName":\s"[^"]+"/, '"moduleName": "<moduleName>"');
       transformed = transformed.replace(/"id":\s"[^"]+"/, '"id": "<id>"');
@@ -1411,15 +1418,16 @@ describe('htmlbars-inline-precompile', function () {
       expect(transformed).toEqualCode(`
         import { createTemplateFactory } from "@ember/template-factory";
         import bar from "bar";
+        import MyButton from 'my-button';
         var compiled = createTemplateFactory(
           /*
-            <Foo />
+            <Foo /><MyButton />
           */
           {
             id: "<id>",
-            block: "[[[8,[32,0],null,null,null]],[],false,[]]",
+            block: "[[[8,[32,0],null,null,null],[8,[32,1],null,null,null]],[],false,[]]",
             moduleName: "<moduleName>",
-            scope: () => [bar],
+            scope: () => [bar, MyButton],
             isStrictMode: false,
           }
         );

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -327,7 +327,8 @@ function remapIdentifiers(ast: Babel.types.File, babel: typeof Babel, scopeLocal
 
   traverse(ast, {
     Identifier(path: NodePath<t.Identifier>) {
-      if (scopeLocals.has(path.node.name)) {
+      if (scopeLocals.has(path.node.name) && path.node.name !== scopeLocals.get(path.node.name)) {
+        // replace the path only if the key is different from the value
         path.replaceWith(babel.types.identifier(scopeLocals.get(path.node.name)));
       }
     },


### PR DESCRIPTION
This PR fixes "maximum call stack exception" when the template is transpiled into the glimmer wire format and there is scope with some different and some equal keys.

```js
scope: ()=> ({
  Message: Message$1,
  Label 
})
```

There was a problem when the key and value were equal in the scope. Identifier was replaced with the same Identifier so there was a "Maximum call stack exception".