### PR TITLE
Fix entity encoding in source-to-source mode

### DIFF
--- a/__tests__/tests.ts
+++ b/__tests__/tests.ts
@@ -1315,6 +1315,20 @@ describe('htmlbars-inline-precompile', function () {
         const other = hbs\`hello\`;
       `);
     });
+
+    it('leaves html entities unchanged when there are no transforms', function () {
+      plugins = [[HTMLBarsInlinePrecompile, { compiler, targetFormat: 'hbs', transforms: [] }]];
+
+      let transformed = transform(stripIndent`
+        import { precompileTemplate } from '@ember/template-compilation';
+        const template = precompileTemplate('&times;');
+      `);
+
+      expect(transformed).toEqualCode(`
+        import { precompileTemplate } from '@ember/template-compilation';
+        const template = precompileTemplate('&times;');
+      `);
+    });
   });
 
   it('removes original import when there are multiple callsites that all needed replacement', function () {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -410,7 +410,7 @@ function insertTransformedTemplate<EnvSpecificOptions>(
     scopeLocals
   );
   let ast = state.normalizedOpts.compiler._preprocess(template, { ...options, mode: 'codemod' });
-  let transformed = state.normalizedOpts.compiler._print(ast);
+  let transformed = state.normalizedOpts.compiler._print(ast, { entityEncoding: 'raw' });
   if (target.isCallExpression()) {
     (target.get('arguments.0') as NodePath<t.Node>).replaceWith(t.stringLiteral(transformed));
     if (!scopeLocals.isEmpty()) {


### PR DESCRIPTION
We were passing the right setting (`mode: 'codemod'`) to the parser, but we *also* have to pass `entityEncoding: 'raw'` to the printer.