### PR TITLE
fix: @babel/traverse is a dependency not a dev-dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "src/**/*.js.map"
   ],
   "dependencies": {
-    "babel-import-util": "^1.3.0"
+    "babel-import-util": "^1.3.0",
+    "@babel/traverse": "^7.14.5"
   },
   "devDependencies": {
     "@babel/core": "^7.14.8",
@@ -42,7 +43,6 @@
     "@babel/plugin-transform-modules-amd": "^7.14.5",
     "@babel/plugin-transform-template-literals": "^7.14.5",
     "@babel/plugin-transform-unicode-escapes": "^7.14.5",
-    "@babel/traverse": "^7.14.5",
     "@glimmer/syntax": "^0.84.2",
     "@types/babel__traverse": "^7.11.1",
     "@types/jest": "^29.2.3",


### PR DESCRIPTION
I think this is what is needed to resolve #23. Not able to test this via `pnpm patch` as apparently package.json dependencies can't be fixed that way. Setting pnpm up like the following which mirrors this change did work:

```json
 "packageExtensions": {
      "babel-plugin-ember-template-compilation": {
        "dependencies": {
          "@babel/traverse": "^7.14.5"
        }
      }
```