### PR TITLE
Don't require compiler when targetFormat='hbs'

### DIFF
--- a/__tests__/tests.ts
+++ b/__tests__/tests.ts
@@ -630,10 +630,7 @@ describe('htmlbars-inline-precompile', function () {
 
   it('allows AST transform to bind a JS expression', function () {
     plugins = [
-      [
-        HTMLBarsInlinePrecompile,
-        { compiler, targetFormat: 'hbs', transforms: [expressionTransform] },
-      ],
+      [HTMLBarsInlinePrecompile, { targetFormat: 'hbs', transforms: [expressionTransform] }],
     ];
 
     let transformed = transform(stripIndent`
@@ -671,9 +668,7 @@ describe('htmlbars-inline-precompile', function () {
   });
 
   it('allows AST transform to bind a JS import', function () {
-    plugins = [
-      [HTMLBarsInlinePrecompile, { compiler, targetFormat: 'hbs', transforms: [importTransform] }],
-    ];
+    plugins = [[HTMLBarsInlinePrecompile, { targetFormat: 'hbs', transforms: [importTransform] }]];
 
     let transformed = transform(stripIndent`
         import { precompileTemplate } from '@ember/template-compilation';
@@ -692,9 +687,7 @@ describe('htmlbars-inline-precompile', function () {
   });
 
   it('does not smash existing js binding for import', function () {
-    plugins = [
-      [HTMLBarsInlinePrecompile, { compiler, targetFormat: 'hbs', transforms: [importTransform] }],
-    ];
+    plugins = [[HTMLBarsInlinePrecompile, { targetFormat: 'hbs', transforms: [importTransform] }]];
 
     let transformed = transform(stripIndent`
         import { precompileTemplate } from '@ember/template-compilation';
@@ -719,9 +712,7 @@ describe('htmlbars-inline-precompile', function () {
   });
 
   it('does not smash existing hbs binding for import', function () {
-    plugins = [
-      [HTMLBarsInlinePrecompile, { compiler, targetFormat: 'hbs', transforms: [importTransform] }],
-    ];
+    plugins = [[HTMLBarsInlinePrecompile, { targetFormat: 'hbs', transforms: [importTransform] }]];
 
     let transformed = transform(stripIndent`
         import { precompileTemplate } from '@ember/template-compilation';
@@ -746,10 +737,7 @@ describe('htmlbars-inline-precompile', function () {
 
   it('does not smash existing js binding for expression', function () {
     plugins = [
-      [
-        HTMLBarsInlinePrecompile,
-        { compiler, targetFormat: 'hbs', transforms: [expressionTransform] },
-      ],
+      [HTMLBarsInlinePrecompile, { targetFormat: 'hbs', transforms: [expressionTransform] }],
     ];
 
     let transformed = transform(stripIndent`
@@ -775,9 +763,7 @@ describe('htmlbars-inline-precompile', function () {
   });
 
   it('reuses existing imports when possible', () => {
-    plugins = [
-      [HTMLBarsInlinePrecompile, { compiler, targetFormat: 'hbs', transforms: [importTransform] }],
-    ];
+    plugins = [[HTMLBarsInlinePrecompile, { targetFormat: 'hbs', transforms: [importTransform] }]];
 
     let transformed = transform(stripIndent`
       import { precompileTemplate } from '@ember/template-compilation';
@@ -794,9 +780,7 @@ describe('htmlbars-inline-precompile', function () {
   });
 
   it('rebinds existing imports when necessary', () => {
-    plugins = [
-      [HTMLBarsInlinePrecompile, { compiler, targetFormat: 'hbs', transforms: [importTransform] }],
-    ];
+    plugins = [[HTMLBarsInlinePrecompile, { targetFormat: 'hbs', transforms: [importTransform] }]];
 
     let transformed = transform(stripIndent`
       import { precompileTemplate } from '@ember/template-compilation';
@@ -817,10 +801,7 @@ describe('htmlbars-inline-precompile', function () {
 
   it('does not smash own newly-created js binding for expression', function () {
     plugins = [
-      [
-        HTMLBarsInlinePrecompile,
-        { compiler, targetFormat: 'hbs', transforms: [expressionTransform] },
-      ],
+      [HTMLBarsInlinePrecompile, { targetFormat: 'hbs', transforms: [expressionTransform] }],
     ];
 
     let transformed = transform(stripIndent`
@@ -852,10 +833,7 @@ describe('htmlbars-inline-precompile', function () {
 
   it('does not smash existing hbs block binding for expression', function () {
     plugins = [
-      [
-        HTMLBarsInlinePrecompile,
-        { compiler, targetFormat: 'hbs', transforms: [expressionTransform] },
-      ],
+      [HTMLBarsInlinePrecompile, { targetFormat: 'hbs', transforms: [expressionTransform] }],
     ];
 
     let transformed = transform(stripIndent`
@@ -880,10 +858,7 @@ describe('htmlbars-inline-precompile', function () {
 
   it('does not smash existing hbs element binding for expression', function () {
     plugins = [
-      [
-        HTMLBarsInlinePrecompile,
-        { compiler, targetFormat: 'hbs', transforms: [expressionTransform] },
-      ],
+      [HTMLBarsInlinePrecompile, { targetFormat: 'hbs', transforms: [expressionTransform] }],
     ];
 
     let transformed = transform(stripIndent`
@@ -908,10 +883,7 @@ describe('htmlbars-inline-precompile', function () {
 
   it('understands that block params are only defined in the body, not the arguments, of an element', function () {
     plugins = [
-      [
-        HTMLBarsInlinePrecompile,
-        { compiler, targetFormat: 'hbs', transforms: [expressionTransform] },
-      ],
+      [HTMLBarsInlinePrecompile, { targetFormat: 'hbs', transforms: [expressionTransform] }],
     ];
 
     let transformed = transform(stripIndent`
@@ -936,10 +908,7 @@ describe('htmlbars-inline-precompile', function () {
 
   it('does not smash other previously-bound expressions with new ones', () => {
     plugins = [
-      [
-        HTMLBarsInlinePrecompile,
-        { compiler, targetFormat: 'hbs', transforms: [expressionTransform] },
-      ],
+      [HTMLBarsInlinePrecompile, { targetFormat: 'hbs', transforms: [expressionTransform] }],
     ];
 
     let transformed = transform(stripIndent`
@@ -981,9 +950,7 @@ describe('htmlbars-inline-precompile', function () {
       };
     };
 
-    plugins = [
-      [HTMLBarsInlinePrecompile, { compiler, targetFormat: 'hbs', transforms: [nowTransform] }],
-    ];
+    plugins = [[HTMLBarsInlinePrecompile, { targetFormat: 'hbs', transforms: [nowTransform] }]];
 
     let transformed = transform(stripIndent`
         import { precompileTemplate } from '@ember/template-compilation';
@@ -1014,9 +981,7 @@ describe('htmlbars-inline-precompile', function () {
       };
     };
 
-    plugins = [
-      [HTMLBarsInlinePrecompile, { compiler, targetFormat: 'hbs', transforms: [compatTransform] }],
-    ];
+    plugins = [[HTMLBarsInlinePrecompile, { targetFormat: 'hbs', transforms: [compatTransform] }]];
 
     let transformed = transform(stripIndent`
       import { precompileTemplate } from '@ember/template-compilation';
@@ -1043,9 +1008,7 @@ describe('htmlbars-inline-precompile', function () {
       };
     };
 
-    plugins = [
-      [HTMLBarsInlinePrecompile, { compiler, targetFormat: 'hbs', transforms: [compatTransform] }],
-    ];
+    plugins = [[HTMLBarsInlinePrecompile, { targetFormat: 'hbs', transforms: [compatTransform] }]];
 
     let transformed = transform(stripIndent`
       import { precompileTemplate } from '@ember/template-compilation';
@@ -1073,9 +1036,7 @@ describe('htmlbars-inline-precompile', function () {
     };
 
     it('can run an ast transform inside precompileTemplate', function () {
-      plugins = [
-        [HTMLBarsInlinePrecompile, { compiler, targetFormat: 'hbs', transforms: [color] }],
-      ];
+      plugins = [[HTMLBarsInlinePrecompile, { targetFormat: 'hbs', transforms: [color] }]];
 
       let transformed = transform(stripIndent`
         import { precompileTemplate } from '@ember/template-compilation';
@@ -1113,10 +1074,7 @@ describe('htmlbars-inline-precompile', function () {
 
     it('can create the options object for precompileTemplate', function () {
       plugins = [
-        [
-          HTMLBarsInlinePrecompile,
-          { compiler, targetFormat: 'hbs', transforms: [expressionTransform] },
-        ],
+        [HTMLBarsInlinePrecompile, { targetFormat: 'hbs', transforms: [expressionTransform] }],
       ];
 
       let transformed = transform(stripIndent`
@@ -1137,10 +1095,7 @@ describe('htmlbars-inline-precompile', function () {
 
     it('adds scope to existing options object', function () {
       plugins = [
-        [
-          HTMLBarsInlinePrecompile,
-          { compiler, targetFormat: 'hbs', transforms: [expressionTransform] },
-        ],
+        [HTMLBarsInlinePrecompile, { targetFormat: 'hbs', transforms: [expressionTransform] }],
       ];
 
       let transformed = transform(stripIndent`
@@ -1166,10 +1121,7 @@ describe('htmlbars-inline-precompile', function () {
 
     it('adds new locals to preexisting scope', function () {
       plugins = [
-        [
-          HTMLBarsInlinePrecompile,
-          { compiler, targetFormat: 'hbs', transforms: [expressionTransform] },
-        ],
+        [HTMLBarsInlinePrecompile, { targetFormat: 'hbs', transforms: [expressionTransform] }],
       ];
 
       let transformed = transform(stripIndent`
@@ -1197,10 +1149,7 @@ describe('htmlbars-inline-precompile', function () {
 
     it('adds new locals to preexisting renamed scope', function () {
       plugins = [
-        [
-          HTMLBarsInlinePrecompile,
-          { compiler, targetFormat: 'hbs', transforms: [expressionTransform] },
-        ],
+        [HTMLBarsInlinePrecompile, { targetFormat: 'hbs', transforms: [expressionTransform] }],
       ];
 
       let transformed = transform(stripIndent`
@@ -1292,7 +1241,6 @@ describe('htmlbars-inline-precompile', function () {
         [
           HTMLBarsInlinePrecompile,
           {
-            compiler,
             targetFormat: 'hbs',
             transforms: [expressionTransform],
             enableLegacyModules: ['ember-cli-htmlbars'],
@@ -1318,7 +1266,7 @@ describe('htmlbars-inline-precompile', function () {
     });
 
     it('leaves html entities unchanged when there are no transforms', function () {
-      plugins = [[HTMLBarsInlinePrecompile, { compiler, targetFormat: 'hbs', transforms: [] }]];
+      plugins = [[HTMLBarsInlinePrecompile, { targetFormat: 'hbs', transforms: [] }]];
 
       let transformed = transform(stripIndent`
         import { precompileTemplate } from '@ember/template-compilation';
@@ -1336,7 +1284,6 @@ describe('htmlbars-inline-precompile', function () {
         [
           HTMLBarsInlinePrecompile,
           {
-            compiler,
             targetFormat: 'hbs',
             transforms: [color],
           },
@@ -1363,7 +1310,6 @@ describe('htmlbars-inline-precompile', function () {
         [
           HTMLBarsInlinePrecompile,
           {
-            compiler,
             targetFormat: 'hbs',
             transforms: [color],
           },
@@ -1402,7 +1348,6 @@ describe('htmlbars-inline-precompile', function () {
         [
           HTMLBarsInlinePrecompile,
           {
-            compiler,
             targetFormat: 'hbs',
             transforms: [color],
           },
@@ -1437,7 +1382,6 @@ describe('htmlbars-inline-precompile', function () {
         [
           HTMLBarsInlinePrecompile,
           {
-            compiler,
             targetFormat: 'hbs',
             transforms: [],
           },
@@ -1465,7 +1409,6 @@ describe('htmlbars-inline-precompile', function () {
       [
         HTMLBarsInlinePrecompile,
         {
-          compiler,
           targetFormat: 'hbs',
           transforms: [expressionTransform],
           enableLegacyModules: ['ember-cli-htmlbars'],

--- a/src/ember-template-compiler.ts
+++ b/src/ember-template-compiler.ts
@@ -1,5 +1,4 @@
-import { ASTv1 } from '@glimmer/syntax';
-import { ExtendedPluginBuilder } from './js-utils';
+import { ASTv1, PreprocessOptions } from '@glimmer/syntax';
 
 // The interface we use from ember-template-compiler.js
 export interface EmberTemplateCompiler {
@@ -9,19 +8,7 @@ export interface EmberTemplateCompiler {
   _preprocess(src: string, options?: PreprocessOptions): ASTv1.Template;
 }
 
-export interface PreprocessOptions {
-  contents: string;
-  moduleName: string;
-  plugins?: { ast?: ExtendedPluginBuilder[] };
-  filename?: string;
-  parseOptions?: {
-    srcName?: string;
-    ignoreStandalone?: boolean;
-  };
-  mode?: 'codemod' | 'precompile';
-  strictMode?: boolean;
-  locals?: string[];
-}
+export { PreprocessOptions };
 
 export function assertTemplateCompiler(
   emberTemplateCompiler: any

--- a/src/node-main.ts
+++ b/src/node-main.ts
@@ -34,7 +34,7 @@ function cwdRequire(moduleName: string) {
 }
 
 function handleNodeSpecificOptions(opts: Options): SharedOptions {
-  let compiler: EmberTemplateCompiler;
+  let compiler: EmberTemplateCompiler | undefined = undefined;
   if (opts.compilerPath) {
     let mod: any = cwdRequire(opts.compilerPath);
     assertTemplateCompiler(mod);
@@ -42,8 +42,6 @@ function handleNodeSpecificOptions(opts: Options): SharedOptions {
   } else if (opts.compiler) {
     assertTemplateCompiler(opts.compiler);
     compiler = opts.compiler;
-  } else {
-    throw new Error(`must provide compilerPath or compiler`);
   }
 
   let transforms = [];

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -7,7 +7,7 @@ import { JSUtils, ExtendedPluginBuilder } from './js-utils';
 import type { EmberTemplateCompiler, PreprocessOptions } from './ember-template-compiler';
 import { LegacyModuleName } from './public-types';
 import { ScopeLocals } from './scope-locals';
-import { getTemplateLocals } from '@glimmer/syntax';
+import { getTemplateLocals, preprocess, print } from '@glimmer/syntax';
 
 export * from './public-types';
 
@@ -51,8 +51,9 @@ const INLINE_PRECOMPILE_MODULES: ModuleConfig[] = [
 ];
 
 export interface Options {
-  // The ember-template-compiler.js module that ships within your ember-source version.
-  compiler: EmberTemplateCompiler;
+  // The ember-template-compiler.js module that ships within your ember-source
+  // version. Mandatory when using targetFormat: 'wire'.
+  compiler?: EmberTemplateCompiler;
 
   // Allows you to remap what imports will be emitted in our compiled output. By
   // example:
@@ -93,9 +94,53 @@ export interface Options {
   transforms?: ExtendedPluginBuilder[];
 }
 
+interface WireOpts {
+  targetFormat: 'wire';
+  compiler: EmberTemplateCompiler;
+  outputModuleOverrides: Record<string, Record<string, [string, string]>>;
+  enableLegacyModules: LegacyModuleName[];
+  transforms: ExtendedPluginBuilder[];
+}
+
+interface HbsOpts {
+  targetFormat: 'hbs';
+  outputModuleOverrides: Record<string, Record<string, [string, string]>>;
+  enableLegacyModules: LegacyModuleName[];
+  transforms: ExtendedPluginBuilder[];
+}
+
+type NormalizedOpts = WireOpts | HbsOpts;
+
+function normalizeOpts(options: Options): NormalizedOpts {
+  if ((options.targetFormat ?? 'wire') === 'wire') {
+    let { compiler } = options;
+    if (!compiler) {
+      throw new Error(
+        `when targetFormat==="wire" you must set the compiler or compilerPath option`
+      );
+    }
+    return {
+      outputModuleOverrides: {},
+      enableLegacyModules: [],
+      transforms: [],
+      ...options,
+      targetFormat: 'wire',
+      compiler,
+    };
+  } else {
+    return {
+      outputModuleOverrides: {},
+      enableLegacyModules: [],
+      transforms: [],
+      ...options,
+      targetFormat: 'hbs',
+    };
+  }
+}
+
 interface State<EnvSpecificOptions> {
   opts: EnvSpecificOptions;
-  normalizedOpts: Required<Options>;
+  normalizedOpts: NormalizedOpts;
   util: ImportUtil;
   templateFactory: { moduleName: string; exportName: string };
   program: NodePath<t.Program>;
@@ -114,14 +159,7 @@ export function makePlugin<EnvSpecificOptions>(loadOptions: (opts: EnvSpecificOp
       visitor: {
         Program: {
           enter(path: NodePath<t.Program>, state: State<EnvSpecificOptions>) {
-            state.normalizedOpts = {
-              targetFormat: 'wire',
-              outputModuleOverrides: {},
-              enableLegacyModules: [],
-              transforms: [],
-              ...loadOptions(state.opts),
-            };
-
+            state.normalizedOpts = normalizeOpts(loadOptions(state.opts));
             state.templateFactory = templateFactoryConfig(state.normalizedOpts);
             state.util = new ImportUtil(t, path);
             state.program = path;
@@ -164,7 +202,16 @@ export function makePlugin<EnvSpecificOptions>(loadOptions: (opts: EnvSpecificOp
 
           let template = path.node.quasi.quasis.map((quasi) => quasi.value.cooked).join('');
           if (state.normalizedOpts.targetFormat === 'wire') {
-            insertCompiledTemplate(babel, state, template, path, {}, config, undefined);
+            insertCompiledTemplate(
+              babel,
+              state,
+              state.normalizedOpts,
+              template,
+              path,
+              {},
+              config,
+              undefined
+            );
           } else {
             insertTransformedTemplate(babel, state, template, path, {}, config, undefined);
           }
@@ -247,6 +294,7 @@ export function makePlugin<EnvSpecificOptions>(loadOptions: (opts: EnvSpecificOp
             insertCompiledTemplate(
               babel,
               state,
+              state.normalizedOpts,
               template,
               path,
               userTypedOptions,
@@ -402,6 +450,7 @@ function remapIdentifiers(ast: Babel.types.File, babel: typeof Babel, scopeLocal
 function insertCompiledTemplate<EnvSpecificOptions>(
   babel: typeof Babel,
   state: State<EnvSpecificOptions>,
+  opts: WireOpts,
   template: string,
   target: NodePath<t.Expression>,
   userTypedOptions: Record<string, unknown>,
@@ -425,13 +474,13 @@ function insertCompiledTemplate<EnvSpecificOptions>(
   // insertRuntimeErrors is legacy and not supported by the newer rfc931 form
   if (options.insertRuntimeErrors && !config.rfc931Support) {
     try {
-      precompileResultString = state.normalizedOpts.compiler.precompile(template, options);
+      precompileResultString = opts.compiler.precompile(template, options);
     } catch (error) {
       target.replaceWith(runtimeErrorIIFE(babel, { ERROR_MESSAGE: (error as any).message }));
       return;
     }
   } else {
-    precompileResultString = state.normalizedOpts.compiler.precompile(template, options);
+    precompileResultString = opts.compiler.precompile(template, options);
   }
 
   let precompileResultAST = babel.parse(`var precompileResult = ${precompileResultString}; `, {
@@ -495,8 +544,8 @@ function insertTransformedTemplate<EnvSpecificOptions>(
     formatOptions,
     scopeLocals
   );
-  let ast = state.normalizedOpts.compiler._preprocess(template, { ...options, mode: 'codemod' });
-  let transformed = state.normalizedOpts.compiler._print(ast, { entityEncoding: 'raw' });
+  let ast = preprocess(template, { ...options, mode: 'codemod' } as any);
+  let transformed = print(ast, { entityEncoding: 'raw' });
   if (target.isCallExpression()) {
     (target.get('arguments.0') as NodePath<t.Node>).replaceWith(t.stringLiteral(transformed));
     if (!scopeLocals.isEmpty()) {
@@ -547,7 +596,7 @@ function insertTransformedTemplate<EnvSpecificOptions>(
   }
 }
 
-function templateFactoryConfig(opts: Required<Options>) {
+function templateFactoryConfig(opts: NormalizedOpts) {
   let moduleName = '@ember/template-factory';
   let exportName = 'createTemplateFactory';
   let overrides = opts.outputModuleOverrides[moduleName]?.[exportName];


### PR DESCRIPTION
When using `targetFormat:' hbs'`, there's no reason to require the `compiler` or `compilerPath` options because the precise version of the compiler doesn't matter. We can use our own `@glimmer/syntax` dependency directly, because the output will be broadly compatible.

It's only `targetFormat: 'wire'` where we require the user provides the ember-version-specific `compiler` or `compilerPath`, because then we're going to output the exact wire format for that version.