### PR TITLE
Update babel-import-util and use it to manage babel bindings more precisely

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "dependencies": {
     "@glimmer/syntax": "^0.84.3",
-    "babel-import-util": "^2.0.0"
+    "babel-import-util": "^2.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.14.8",

--- a/src/js-utils.ts
+++ b/src/js-utils.ts
@@ -258,6 +258,11 @@ class ExpressionContext {
    * @return the local identifier for the imported value
    */
   import(moduleSpecifier: string, exportedName: string, nameHint?: string): string {
+    // this method in babel-import-util is the lower-level one that doesn't try
+    // to create valid references for us. It's our responsibility to do so. But
+    // that's OK here, because we have the same responsibility for every
+    // scope-bag identifier, not just the imported ones, and it will be easier
+    // to handle them all at once.
     return this.#importer.import(this.#target, moduleSpecifier, exportedName, nameHint).name;
   }
 }

--- a/src/scope-locals.ts
+++ b/src/scope-locals.ts
@@ -59,10 +59,6 @@ export class ScopeLocals {
     return this.#locals.length === 0;
   }
 
-  needsRemapping(): boolean {
-    return Object.entries(this.#mapping).some(([k, v]) => k !== v);
-  }
-
   entries() {
     return Object.entries(this.#mapping);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2023,10 +2023,10 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-babel-import-util@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/babel-import-util/-/babel-import-util-2.0.0.tgz#99a2e7424bcde01898bc61bb19700ff4c74379a3"
-  integrity sha512-pkWynbLwru0RZmA9iKeQL63+CkkW0RCP3kL5njCtudd6YPUKb5Pa0kL4fb3bmuKn2QDBFwY5mvvhEK/+jv2Ynw==
+babel-import-util@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/babel-import-util/-/babel-import-util-2.1.0.tgz#fa1ff9082165343d24a1260d2874b3ce1fef3246"
+  integrity sha512-iL9toY75NhvsNfy4dtjA/9C8B2X1IXSho5KVamya8z9jbozyPW0Fj70xBV+Quki/Cijdj/ANMb85sncTnvIvZg==
 
 babel-jest@^29.6.4:
   version "29.6.4"


### PR DESCRIPTION
This switches most of our usage to the new automatic-reference APIs in babel-import-util.

The only remaining place where we're responsible for managing the references ourselves is ones introduced by `jsutils.bindImport`. But we're already responsible for managing references to everything in the scope bag anyway, so that is appropriate.

This refactors the scope-bag-reference management so it happens more precisely, directly against the scope bag (in 'hbs' target mode) or the locals array (in 'wire' target mode). This should result in a slightly more efficient plugin, since we're recrawling a small set of the AST to establish references.