### PR TITLE
Remove extraneous import from `@ember/template-compiler`

### DIFF
--- a/__tests__/tests.ts
+++ b/__tests__/tests.ts
@@ -2139,63 +2139,6 @@ describe('htmlbars-inline-precompile', function () {
         `);
     });
 
-    it('works with two components', function () {
-      plugins = [
-        [
-          HTMLBarsInlinePrecompile,
-          {
-            targetFormat: 'hbs',
-          },
-        ],
-      ];
-
-      let p = new Preprocessor();
-      let processed = p.process(
-        `
-        import Component from '@glimmer/component';
-
-        export default class Test extends Component {
-          foo = 1;
-
-          <template>
-            <Icon />
-          </template>
-        }
-
-        const Icon = <template>Icon</template>;
-        `
-      );
-
-      let transformed = transform(processed);
-
-      expect(transformed).toEqualCode(`
-        import Component from "@glimmer/component";
-        import { precompileTemplate } from "@ember/template-compilation";
-        import { setComponentTemplate } from "@ember/component";
-        import templateOnly from "@ember/component/template-only";
-        export default class Test extends Component {
-          foo = 1;
-          static {
-            setComponentTemplate(
-              precompileTemplate("\\n            <Icon />\\n          ", {
-                strictMode: true,
-                scope: () => ({
-                  Icon,
-                }),
-              }),
-              this
-            );
-          }
-        }
-        const Icon = setComponentTemplate(
-          precompileTemplate("Icon", {
-            strictMode: true,
-          }),
-          templateOnly()
-        );
-    `);
-    });
-
     it('works for class member form with `this` references', function () {
       plugins = [
         [

--- a/__tests__/tests.ts
+++ b/__tests__/tests.ts
@@ -1478,7 +1478,7 @@ describe('htmlbars-inline-precompile', function () {
       `);
     });
 
-    it('cleans up leftover imports when polyfilling rfc931 with hbs target', function () {
+    it('cleans up leftover imports when there is more than one template', function () {
       plugins = [
         [
           HTMLBarsInlinePrecompile,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -629,23 +629,12 @@ function updateCallForm<EnvSpecificOptions>(
           ),
       ])
     );
-
     // we just wrapped the target callExpression in the call to
     // setComponentTemplate. Adjust `target` back to point at the
     // precompileTemplate call for the final updateScope below.
     //
     target = target.get('arguments.0') as NodePath<t.CallExpression>;
   }
-
-  // Changing imports/identifiers doesn't automatically update the scope.
-  //
-  // NOTE: https://github.com/babel/babel/issues/7974
-  //
-  // We need to refresh ourselves
-  // This is expensive, but required so that maybePruneImport
-  // has a chance to prune imports when their specifiers are no longer used.
-  state.program.scope.crawl();
-
   // We deliberately do updateScope at the end so that when it updates
   // references, those references will point to the accurate paths in the
   // final AST.
@@ -774,18 +763,26 @@ function maybePruneImport(
     return;
   }
   let binding = identifier.scope.getBinding(identifier.node.name);
-  // this checks if the identifier (that we're about to remove) is used in
-  // exactly one place.
-  if (
-    binding?.referencePaths.reduce((count, path) => (path.removed ? count : count + 1), 0) === 1
-  ) {
+
+  if (!binding) {
+    return;
+  }
+
+  let found = binding.referencePaths.find((path) => path.node === identifier.node);
+  if (!found) {
+    return;
+  }
+
+  binding.referencePaths.splice(binding.referencePaths.indexOf(found), 1);
+  binding.references--;
+
+  if (binding.references === 0) {
     let specifier = binding.path;
     if (specifier.isImportSpecifier()) {
       let declaration = specifier.parentPath as NodePath<t.ImportDeclaration>;
       util.removeImport(declaration.node.source.value, name(specifier.node.imported));
     }
   }
-  identifier.removed = true;
 }
 
 function precompileTemplate(i: Importer) {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -629,12 +629,22 @@ function updateCallForm<EnvSpecificOptions>(
           ),
       ])
     );
+
     // we just wrapped the target callExpression in the call to
     // setComponentTemplate. Adjust `target` back to point at the
     // precompileTemplate call for the final updateScope below.
     //
     target = target.get('arguments.0') as NodePath<t.CallExpression>;
   }
+
+  // Changing imports/identifiers doesn't automatically update the scope.
+  //
+  // NOTE: https://github.com/babel/babel/issues/7974
+  //
+  // We need to refresh ourselves
+  // This is expensive, but required so that maybePruneImport
+  // has a chance to prune imports when their specifiers are no longer used.
+  state.program.scope.crawl();
 
   // We deliberately do updateScope at the end so that when it updates
   // references, those references will point to the accurate paths in the


### PR DESCRIPTION
## First commit:
demonstrates a failing test where `@ember/template-compiler` is left in the output code.
This manifests itself in the default blueprint when two components exist in the same file:

<details><summary>reproduction is simple</summary>

Input code:
```gjs
import Component from '@glimmer/component';

export default class Test extends Component {
  foo = 1;

  <template><Icon /></template>
}

const Icon = <template>Icon</template>;
```

Which is intermediately (still correct):
```js
import { template } from "@ember/template-compiler";
import Component from '@glimmer/component';
export default class Test extends Component {
    foo = 1;
    static{
        template("<Icon />", {
            component: this,
            eval () {
                return eval(arguments[0]);
            }
        });
    }
}
const Icon = template("Icon", {
    eval () {
        return eval(arguments[0]);
    }
});

```        

Output code:
```js
import '@ember/template-compiler';
import Component from '@glimmer/component';
import { precompileTemplate } from '@ember/template-compilation';
import { setComponentTemplate } from '@ember/component';
import templateOnly from '@ember/component/template-only';

class Test extends Component {
  foo = 1;
  static {
    setComponentTemplate(precompileTemplate("<Icon />", {
      strictMode: true,
      scope: () => ({
        Icon
      })
    }), this);
  }
}
const Icon = setComponentTemplate(precompileTemplate("Icon", {
  strictMode: true
}), templateOnly());

export { Test as default };
//# sourceMappingURL=test.js.map
```


</details>

Rollup detects that `{ template }` is unused, but then leaves a side-effecting import for `@ember/template-compiler`
