### PR TITLE
Problem with generating scope locals (the wire format array) when scope bag (the object) has aliasing properties (non-shorthand)

### DIFF
--- a/__tests__/tests.ts
+++ b/__tests__/tests.ts
@@ -377,16 +377,29 @@ describe('htmlbars-inline-precompile', function () {
 
     let transformed = transform(code);
 
-    /**
-     * Have to choose our line because `moduleName` differs per-machine.
-     */
-    let scope = transformed
-      .split('\n')
-      .find((line) => line.includes('scope'))
-      ?.trim();
+    let normalized = normalizeWireFormat(transformed);
 
-    // Not [Foo]
-    expect(scope).toEqual('"scope": () => [Setup],');
+    expect(normalized).toEqualCode(`
+      import { Setup } from "./foo.js";
+      import { setComponentTemplate } from "@ember/component";
+      import templateOnly from "@ember/component/template-only";
+      import { createTemplateFactory } from "@ember/template-factory";
+      export default setComponentTemplate(
+        createTemplateFactory(
+          /*
+            <Foo />
+          */
+          {
+            id: "<id>",
+            block: "[[[8,[32,0],null,null,null]],[],false,[]]",
+            moduleName: "<moduleName>",
+            scope: () => [Setup],
+            isStrictMode: true,
+          }
+        ),
+        templateOnly()
+      );
+    `);
   });
 
   it('does not fully remove imports that have other imports', function () {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -482,6 +482,12 @@ function insertCompiledTemplate<EnvSpecificOptions>(
       return;
     }
   } else {
+    // The emitted `scope: () => []` here could potentially be wrong,
+    // as it does not know about the values in JS Scope.
+    // the scope that we pass to precompile tells the compiler what to expect will be
+    // in scope at runtime.
+    // but when we emit the final scope array, we need to make sure we map back to
+    // the assignments / renames in the scope-bag from the pre-wireformat
     precompileResultString = opts.compiler.precompile(template, options);
   }
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -487,7 +487,8 @@ function insertCompiledTemplate<EnvSpecificOptions>(
     // the scope that we pass to precompile tells the compiler what to expect will be
     // in scope at runtime.
     // but when we emit the final scope array, we need to make sure we map back to
-    // the assignments / renames in the scope-bag from the pre-wireformat
+    // the assignments / renames in the scope-bag from the pre-wirenformat
+    // (which can be seen in target.toString())
     precompileResultString = opts.compiler.precompile(template, options);
   }
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -500,6 +500,8 @@ function insertCompiledTemplate<EnvSpecificOptions>(
   let templateExpression = (precompileResultAST.program.body[0] as t.VariableDeclaration)
     .declarations[0].init as t.Expression;
 
+  updateGlimmerScopeWithBabelScope(babel, templateExpression, scopeLocals);
+
   t.addComment(
     templateExpression,
     'leading',
@@ -670,6 +672,43 @@ function buildScope(babel: typeof Babel, locals: ScopeLocals) {
         )
     )
   );
+}
+
+// templateExpression.properties[]:
+//   [0]: key.value = id
+//   [1]: key.value = block
+//   [2]: key.value = moduleName
+//   [3]: key.value = scope         <-- this is what needs updating
+//   [4]: key.value = isStrictMode
+function updateGlimmerScopeWithBabelScope(
+  babel: typeof Babel,
+  templateExpression: t.Expression,
+  scopeLocals: ScopeLocals
+) {
+  let t = babel.types;
+
+  if (t.isObjectExpression(templateExpression)) {
+    let scopeObjectProperty = templateExpression.properties.find((property) => {
+      if (t.isObjectProperty(property)) {
+        return t.isStringLiteral(property.key) && property.key.value === 'scope';
+      }
+      return false;
+    });
+
+    if (t.isObjectProperty(scopeObjectProperty)) {
+      let scopeValue = scopeObjectProperty.value;
+
+      if (t.isArrowFunctionExpression(scopeValue)) {
+        if (t.isArrayExpression(scopeValue.body)) {
+          scopeValue.body.elements.map((element) => {
+            if (t.isIdentifier(element)) {
+              element.name = scopeLocals.get(element.name);
+            }
+          });
+        }
+      }
+    }
+  }
 }
 
 // this is responsible both for adjusting the AST for our scope argument *and*


### PR DESCRIPTION
e2e repro: https://github.com/NullVoxPopuli/repro-v2-addon-scope-bag-to-wireformat-when-consumed-loses-binding
(try loading /tests)

This scenario happens within Babel (somewhere) when
`import { Setup as Foo } from '...'` is done.
The import alias is undone, and the aliasing is moved to the usage location.

Being wrapped in setComponentTemplate is required, else the scope bag is correct
(ie: [Setup]).

for Example:

<details><summary>original source</summary>

```gjs
import { Setup as LunaSetup } from './foo.gts';

<template><LunaSetup /></template>
```

<details><summary>actual original in the reproduction here</summary>

```gjs
import { Setup as LunaSetup } from './foo.gts';
import { render } from '@ember/test-helpers';

export async function renderViewsFor() {
  await render(<template><LunaSetup /></template>);
}
```

</details>

</details>

Input:
```js
import { Setup } from './foo.js';
import { precompileTemplate } from '@ember/template-compilation';
import { setComponentTemplate } from '@ember/component';
import templateOnly from '@ember/component/template-only';

  setComponentTemplate(precompileTemplate("<Foo />", {
    strictMode: true,
    scope: () => ({
      Foo: Setup
    })
  }), templateOnly());
```
Output:
```js
import { Setup } from './foo.js';
import { setComponentTemplate } from '@ember/component';
import templateOnly from '@ember/component/template-only';
import { createTemplateFactory } from "@ember/template-factory";
setComponentTemplate(createTemplateFactory(
/*
  <Foo />
*/
{
  "id": "7TRZhmiQ",
  "block": "[[[8,[32,0],null,null,null]],[],false,[]]",
  "moduleName": "<way too long/>babel-plugin-ember-template-compilation/foo-bar.js",
  "scope": () => [Foo],
  "isStrictMode": true
}), templateOnly());
```
Which is wrong, because `Foo` doesn't exist :upside_down_face: 

Scope should be:
```
  "scope": () => [Setup],
```