### PR TITLE
add template only name

### DIFF
--- a/__tests__/tests.ts
+++ b/__tests__/tests.ts
@@ -1468,7 +1468,7 @@ describe('htmlbars-inline-precompile', function () {
         import { precompileTemplate } from "@ember/template-compilation";
         import { setComponentTemplate } from "@ember/component";
         import templateOnly from "@ember/component/template-only";
-        export default setComponentTemplate(precompileTemplate('<HelloWorld @color={{"#ff0000"}} />', { scope: () => ({ HelloWorld }), strictMode: true }), templateOnly());
+        export default setComponentTemplate(precompileTemplate('<HelloWorld @color={{"#ff0000"}} />', { scope: () => ({ HelloWorld }), strictMode: true }), templateOnly(undefined, "foo-bar"));
       `);
     });
 
@@ -1599,7 +1599,7 @@ describe('htmlbars-inline-precompile', function () {
           precompileTemplate("Icon", {
             strictMode: true,
           }),
-          templateOnly()
+          templateOnly(undefined, "Icon")
         );
       `);
     });
@@ -1626,7 +1626,7 @@ describe('htmlbars-inline-precompile', function () {
         import { precompileTemplate } from "@ember/template-compilation";
         import { setComponentTemplate } from "@ember/component";
         import templateOnly from "@ember/component/template-only";
-        export default setComponentTemplate(precompileTemplate('<HelloWorld />', { strictMode: false, scope: () => ({ HelloWorld }) }), templateOnly());
+        export default setComponentTemplate(precompileTemplate('<HelloWorld />', { strictMode: false, scope: () => ({ HelloWorld }) }), templateOnly(undefined, "foo-bar"));
       `);
     });
   });
@@ -1698,7 +1698,7 @@ describe('htmlbars-inline-precompile', function () {
           scope: () => [HelloWorld],
           isStrictMode: true,
         }
-      ), templateOnly());    
+      ), templateOnly(undefined, "foo-bar"));    
     `);
   });
 
@@ -1897,7 +1897,7 @@ describe('htmlbars-inline-precompile', function () {
         import { precompileTemplate } from "@ember/template-compilation";
         import { setComponentTemplate } from "@ember/component";
         import templateOnly from "@ember/component/template-only";
-        export default setComponentTemplate(precompileTemplate('<HelloWorld />', { strictMode: true, scope: () => ({ HelloWorld }) }), templateOnly());
+        export default setComponentTemplate(precompileTemplate('<HelloWorld />', { strictMode: true, scope: () => ({ HelloWorld }) }), templateOnly(undefined, "foo-bar"));
       `);
     });
 
@@ -1928,7 +1928,7 @@ describe('htmlbars-inline-precompile', function () {
         import { setComponentTemplate } from "@ember/component";
         import templateOnly from "@ember/component/template-only";
         let div = 1;
-        export default setComponentTemplate(precompileTemplate('<div></div>', { strictMode: true, scope: () => ({ div })}), templateOnly());
+        export default setComponentTemplate(precompileTemplate('<div></div>', { strictMode: true, scope: () => ({ div })}), templateOnly(undefined, "foo-bar"));
       `);
     });
 
@@ -1955,7 +1955,7 @@ describe('htmlbars-inline-precompile', function () {
         import { setComponentTemplate } from "@ember/component";
         import templateOnly from "@ember/component/template-only";
         let hasBlock = 1;
-        export default setComponentTemplate(precompileTemplate('{{hasBlock "thing"}}', { strictMode: true, scope: () => ({ hasBlock }) }), templateOnly());
+        export default setComponentTemplate(precompileTemplate('{{hasBlock "thing"}}', { strictMode: true, scope: () => ({ hasBlock }) }), templateOnly(undefined, "foo-bar"));
       `);
     });
 
@@ -1980,7 +1980,7 @@ describe('htmlbars-inline-precompile', function () {
         import { precompileTemplate } from "@ember/template-compilation";
         import { setComponentTemplate } from "@ember/component";
         import templateOnly from "@ember/component/template-only";
-        export default setComponentTemplate(precompileTemplate('{{hasBlock "thing"}}', { strictMode: true }), templateOnly());
+        export default setComponentTemplate(precompileTemplate('{{hasBlock "thing"}}', { strictMode: true }), templateOnly(undefined, "foo-bar"));
       `);
     });
 
@@ -2020,7 +2020,7 @@ describe('htmlbars-inline-precompile', function () {
               isStrictMode: true,
             }
           ),
-           templateOnly()
+           templateOnly(undefined, "foo-bar")
         );
       `);
     });
@@ -2049,7 +2049,7 @@ describe('htmlbars-inline-precompile', function () {
         import { precompileTemplate } from "@ember/template-compilation";
         import { setComponentTemplate } from "@ember/component";
         import templateOnly from "@ember/component/template-only";
-        export default setComponentTemplate(precompileTemplate('<HelloWorld />', { strictMode: true, scope: () => ({ HelloWorld }) }), templateOnly());
+        export default setComponentTemplate(precompileTemplate('<HelloWorld />', { strictMode: true, scope: () => ({ HelloWorld }) }), templateOnly(undefined, "foo-bar"));
       `);
     });
 
@@ -2081,7 +2081,7 @@ describe('htmlbars-inline-precompile', function () {
         import templateOnly from "@ember/component/template-only";
         export default function() {
           let { HelloWorld } = globalThis;
-          return setComponentTemplate(precompileTemplate('<HelloWorld />', { strictMode: true, scope: () => ({ HelloWorld })}), templateOnly());
+          return setComponentTemplate(precompileTemplate('<HelloWorld />', { strictMode: true, scope: () => ({ HelloWorld })}), templateOnly(undefined, undefined));
         }
       `);
     });
@@ -2133,7 +2133,7 @@ describe('htmlbars-inline-precompile', function () {
           isStrictMode: true,
         }
       ),
-      templateOnly()
+      templateOnly(undefined, "foo-bar")
     );
       `);
     });
@@ -2166,7 +2166,7 @@ describe('htmlbars-inline-precompile', function () {
           import { precompileTemplate } from "@ember/template-compilation";
           import { setComponentTemplate } from "@ember/component";
           import templateOnly from "@ember/component/template-only";
-          const MyComponent = setComponentTemplate(precompileTemplate('<HelloWorld />', { strictMode: true, scope: () => ({ HelloWorld })  }), templateOnly());
+          const MyComponent = setComponentTemplate(precompileTemplate('<HelloWorld />', { strictMode: true, scope: () => ({ HelloWorld })  }), templateOnly(undefined, "MyComponent"));
         `);
     });
 

--- a/__tests__/tests.ts
+++ b/__tests__/tests.ts
@@ -1599,7 +1599,7 @@ describe('htmlbars-inline-precompile', function () {
           precompileTemplate("Icon", {
             strictMode: true,
           }),
-          templateOnly(undefined, "Icon")
+          templateOnly(undefined, "foo-bar:Icon")
         );
       `);
     });
@@ -2166,7 +2166,7 @@ describe('htmlbars-inline-precompile', function () {
           import { precompileTemplate } from "@ember/template-compilation";
           import { setComponentTemplate } from "@ember/component";
           import templateOnly from "@ember/component/template-only";
-          const MyComponent = setComponentTemplate(precompileTemplate('<HelloWorld />', { strictMode: true, scope: () => ({ HelloWorld })  }), templateOnly(undefined, "MyComponent"));
+          const MyComponent = setComponentTemplate(precompileTemplate('<HelloWorld />', { strictMode: true, scope: () => ({ HelloWorld })  }), templateOnly(undefined, "foo-bar:MyComponent"));
         `);
     });
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -498,7 +498,7 @@ function insertCompiledTemplate<EnvSpecificOptions>(
     let expression = t.callExpression(templateFactoryIdentifier, [templateExpression]);
 
     let assignment = target.parent;
-    let assignmentName: t.StringLiteral = t.stringLiteral(state.filename);
+    let assignmentName: t.StringLiteral | t.Identifier = t.identifier('undefined');
     if (assignment.type === 'AssignmentExpression' && assignment.left.type === 'Identifier') {
       assignmentName = t.stringLiteral(assignment.left.name);
     }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -507,7 +507,7 @@ function insertCompiledTemplate<EnvSpecificOptions>(
       assignmentName = t.stringLiteral(rootName + ':' + assignment.id.name);
     }
     if (assignment.type === 'ExportDefaultDeclaration') {
-      assignmentName = t.stringLiteral(name);
+      assignmentName = t.stringLiteral(rootName);
     }
 
     if (config.rfc931Support) {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -498,15 +498,15 @@ function insertCompiledTemplate<EnvSpecificOptions>(
     let expression = t.callExpression(templateFactoryIdentifier, [templateExpression]);
 
     let assignment = target.parent;
+    let rootName = basename(state.filename).slice(0, -extname(state.filename).length);
     let assignmentName: t.StringLiteral | t.Identifier = t.identifier('undefined');
     if (assignment.type === 'AssignmentExpression' && assignment.left.type === 'Identifier') {
-      assignmentName = t.stringLiteral(assignment.left.name);
+      assignmentName = t.stringLiteral(rootName + ':' + assignment.left.name);
     }
     if (assignment.type === 'VariableDeclarator' && assignment.id.type === 'Identifier') {
-      assignmentName = t.stringLiteral(assignment.id.name);
+      assignmentName = t.stringLiteral(rootName + ':' + assignment.id.name);
     }
     if (assignment.type === 'ExportDefaultDeclaration') {
-      const name = basename(state.filename).slice(0, -extname(state.filename).length);
       assignmentName = t.stringLiteral(name);
     }
 
@@ -622,13 +622,14 @@ function updateCallForm<EnvSpecificOptions>(
     target.node.arguments = target.node.arguments.slice(0, 2);
 
     let assignment = target.parent;
+    let rootName = basename(state.filename).slice(0, -extname(state.filename).length);
     let assignmentName: Babel.types.Identifier | Babel.types.StringLiteral =
       babel.types.identifier('undefined');
     if (assignment.type === 'AssignmentExpression' && assignment.left.type === 'Identifier') {
-      assignmentName = babel.types.stringLiteral(assignment.left.name);
+      assignmentName = babel.types.stringLiteral(rootName + ':' + assignment.left.name);
     }
     if (assignment.type === 'VariableDeclarator' && assignment.id.type === 'Identifier') {
-      assignmentName = babel.types.stringLiteral(assignment.id.name);
+      assignmentName = babel.types.stringLiteral(rootName + ':' + assignment.id.name);
     }
     if (assignment.type === 'ExportDefaultDeclaration') {
       const name = basename(state.filename).slice(0, -extname(state.filename).length);


### PR DESCRIPTION
this is for inspector to show template only component names.

`templateOnly` takes 2 params moduleName and name. https://github.com/glimmerjs/glimmer-vm/blob/10eae7429b702b1e7f5434b91802d5767ff7ad9a/packages/%40glimmer/runtime/lib/component/template-only.ts#L84

and have their [defaults](https://github.com/glimmerjs/glimmer-vm/blob/10eae7429b702b1e7f5434b91802d5767ff7ad9a/packages/%40glimmer/runtime/lib/component/template-only.ts#L45) set to
```js
  public moduleName = '@glimmer/component/template-only',
  public name = '(unknown template-only component)'
```

I had to update dependencies to test locally... #59 