### PR TITLE
Provide a default compilerPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ interface Options {
   compiler?: EmberTemplateCompiler;
 
   // The on-disk path to the ember-template-compiler.js module for our current
-  // ember version. You need to either set `compilerPath` or set `compiler`.
+  // ember version. You may set `compilerPath` or set `compiler`.
   // This will get resolved from the current working directory, so a package name
-  // like "ember-source/dist/ember-template-compiler" is acceptable.
+  // like "ember-source/dist/ember-template-compiler" (the default value) is acceptable. 
   compilerPath?: string;
 
   // Allows you to remap what imports will be emitted in our compiled output. By

--- a/src/node-main.ts
+++ b/src/node-main.ts
@@ -10,12 +10,15 @@ export * from './public-types';
 export type Transform = ExtendedPluginBuilder | string | [string, unknown];
 
 export type Options = Omit<SharedOptions, 'transforms' | 'compiler'> & {
-  // The on-disk path to the ember-template-comipler.js module for our current
-  // ember version. You need to either set `compilerPath` or set `compiler`.
+  // The on-disk path to the ember-template-compiler.js module for our current
+  // ember version. You can set either `compilerPath` or set `compiler`. If you
+  // set neither, we will attempt to resolve
+  // "ember-source/dist/ember-template-compiler.js" from the current working
+  // directory.
   compilerPath?: string;
 
   // The ember-template-compiler.js module that ships within your ember-source
-  // version. You need to set either `compilerPath` or `compiler`.
+  // version. You can set either `compilerPath` or `compiler`.
   compiler?: EmberTemplateCompiler;
 
   // List of custom transformations to apply to the handlebars AST before
@@ -42,6 +45,10 @@ function handleNodeSpecificOptions(opts: Options): SharedOptions {
   } else if (opts.compiler) {
     assertTemplateCompiler(opts.compiler);
     compiler = opts.compiler;
+  } else {
+    let mod: any = cwdRequire('ember-source/dist/ember-template-compiler.js');
+    assertTemplateCompiler(mod);
+    compiler = mod;
   }
 
   let transforms = [];


### PR DESCRIPTION
This is a convenience feature due to the fact that embroider is about to offer a "normal" babel config where users will be looking directly at babel-plugin-ember-template-compilation.