### PR TITLE
Fix incorrect "this" binding when there's a TypeScript `this` arg in scope

### DIFF
--- a/__tests__/tests.ts
+++ b/__tests__/tests.ts
@@ -2151,6 +2151,65 @@ describe('htmlbars-inline-precompile', function () {
       `);
     });
 
+    it('does not captures lexical "this" when template is used in class body even when a TS "this" is in scope', async function () {
+      plugins = [
+        [
+          HTMLBarsInlinePrecompile,
+          {
+            compiler,
+            targetFormat: 'hbs',
+          },
+        ],
+        TransformTypescript,
+      ];
+
+      let transformed = await transform(
+        `import { template } from '@ember/template-compiler'; 
+        import Component from '@glimmer/component';
+
+        function someHelper() {}
+        
+        export function example(this: unknown) {
+        
+          class Example extends Component {
+            upper(s) { return s.toUpperCase() }
+            message = "hi";
+            static {
+              template('{{this.upper (someHelper this.message) }}', { component: this, eval: function() { return eval(arguments[0]) } })
+            }
+          }
+
+        }
+        `
+      );
+
+      expect(transformed).toEqualCode(`
+        import Component from "@glimmer/component";
+        import { precompileTemplate } from "@ember/template-compilation";
+        import { setComponentTemplate } from "@ember/component";
+
+        function someHelper() {}
+
+        export function example() {
+          class Example extends Component {
+            upper(s) {
+              return s.toUpperCase();
+            }
+            message = "hi";
+            static {
+              setComponentTemplate(
+                precompileTemplate("{{this.upper (someHelper this.message)}}", {
+                  strictMode: true,
+                  scope: () => ({ someHelper }),
+                }),
+                this
+              );
+            }
+          }
+        }
+      `);
+    });
+
     it('leaves ember keywords alone when no local is defined', async function () {
       plugins = [
         [

--- a/src/scope-locals.ts
+++ b/src/scope-locals.ts
@@ -164,8 +164,10 @@ export class ScopeLocals {
                 // all hbs upvars that have matching JS bindings go into the
                 // scope
                 for (let name of seen) {
-                  if (name === 'this' && this.#params.mayUseLexicalThis) {
-                    this.add(name);
+                  if (name === 'this') {
+                    if (this.#params.mayUseLexicalThis) {
+                      this.add(name);
+                    }
                   } else if (this.#isInJsScope(name, this.#params.jsPath)) {
                     this.add(name);
                   }


### PR DESCRIPTION
Our `mayUseLexicalThis` guard was not fully guarding against treating a template's `this` as the lexically scoped one. This went unnoticed because to trigger the bug you also need babel to tell you that the identifier `this` is in scope, which normally won't happen, except in TypeScript with a `this` function argument.

Fixes https://github.com/emberjs/babel-plugin-ember-template-compilation/issues/79