### PR TITLE
Don't try to auto-detect ember template compiler when targetFormat do…

### DIFF
--- a/src/node-main.ts
+++ b/src/node-main.ts
@@ -50,7 +50,7 @@ async function handleNodeSpecificOptions(opts: Options): Promise<SharedOptions> 
   } else if (opts.compiler) {
     assertTemplateCompiler(opts.compiler);
     compiler = opts.compiler;
-  } else {
+  } else if (opts.targetFormat === 'wire') {
     let mod: any = await cwdImport('ember-source/dist/ember-template-compiler.js');
     assertTemplateCompiler(mod);
     compiler = mod;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -115,9 +115,7 @@ function normalizeOpts(options: Options): NormalizedOpts {
   if ((options.targetFormat ?? 'wire') === 'wire') {
     let { compiler } = options;
     if (!compiler) {
-      throw new Error(
-        `when targetFormat==="wire" you must set the compiler or compilerPath option`
-      );
+      throw new Error(`when targetFormat==="wire" you must provide the ember template compiler`);
     }
     return {
       outputModuleOverrides: {},


### PR DESCRIPTION
…esn't need it