### PR TITLE
Fix a windows import bug

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -43,7 +43,7 @@ jobs:
     name: Floating dependencies
     strategy:
       matrix:
-        node: ['18', '22']
+        node: ['18', '20', '22']
         os: ['ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
     steps:

--- a/__tests__/mock-transform.ts
+++ b/__tests__/mock-transform.ts
@@ -1,0 +1,18 @@
+import { ExtendedPluginBuilder } from '../src/js-utils.js';
+
+let expressionTransform: ExtendedPluginBuilder = (env) => {
+  return {
+    name: 'expression-transform',
+    visitor: {
+      PathExpression(node, path) {
+        if (node.original === 'onePlusOne') {
+          let name = env.meta.jsutils.bindExpression('1+1', path, { nameHint: 'two' });
+          return env.syntax.builders.path(name);
+        }
+        return undefined;
+      },
+    },
+  };
+};
+
+export default expressionTransform;

--- a/__tests__/tests.ts
+++ b/__tests__/tests.ts
@@ -729,6 +729,33 @@ describe('htmlbars-inline-precompile', function () {
     `);
   });
 
+  it('can load a transform from an absolute path', async function () {
+    plugins = [
+      [
+        HTMLBarsInlinePrecompile,
+        {
+          targetFormat: 'hbs',
+          transforms: [fileURLToPath(new URL('./mock-transform', import.meta.url))],
+        },
+      ],
+    ];
+
+    let transformed = await transform(stripIndent`
+        import { precompileTemplate } from '@ember/template-compilation';
+        const template = precompileTemplate('<Message @text={{onePlusOne}} />');
+      `);
+
+    expect(transformed).toEqualCode(`
+      import { precompileTemplate } from '@ember/template-compilation';
+      let two = 1 + 1;
+      const template = precompileTemplate("<Message @text={{two}} />", {
+        scope: () => ({
+          two
+        })
+      });
+    `);
+  });
+
   it('adds locals to the compiled output', async function () {
     plugins = [
       [

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "jest": {
     "testPathIgnorePatterns": [
       "mock-precompile",
+      "mock-transform",
       ".*\\.ts"
     ]
   },

--- a/src/node-main.ts
+++ b/src/node-main.ts
@@ -35,6 +35,15 @@ export type Options = Omit<SharedOptions, 'transforms' | 'compiler'> & {
 
 async function cwdImport(moduleName: string) {
   let target = importMetaResolve(moduleName, pathToFileURL(process.cwd() + sep).href);
+  if (!target.startsWith('file:')) {
+    // import-meta-resolve doesn't consistently return file URLs rather than paths
+    // https://github.com/wooorm/import-meta-resolve/issues/31
+    //
+    // also, under some conditions which I have not been able to reproduce in
+    // the test suite, Windows will error if you pass an absolute path that is
+    // not a file: URL.
+    target = pathToFileURL(target).href;
+  }
   return esCompat(await import(target));
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     // Compilation Configuration
-    "target": "es2015",
+    "target": "es2020",
     "module": "nodenext",
     "inlineSources": true,
     "inlineSourceMap": true,


### PR DESCRIPTION
`import-meta-resolve` sometimes returns paths instead of file: URLs.

Windows sometimes throws if you try to `import()` an absolute path that is not a file URL.

I couldn't reproduce this in the test suite, I suspect Jest's module shenanigans.