### PR TITLE
avoid leaking real filename path in output due to moduleName

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -405,14 +405,7 @@ function buildPrecompileOptions<EnvSpecificOptions>(
     // don't account for extension
     meta: meta as PreprocessOptions['meta'],
 
-    // TODO: embroider's template-compiler allows this to be overriden to get
-    // backward-compatible module names that don't match the real name of the
-    // on-disk file. What's our plan for migrating people away from that?
-    moduleName: state.filename,
-
-    // This is here so it's *always* the real filename. Historically, there is
-    // also `moduleName` but that did not match the real on-disk filename, it
-    // was the notional runtime module name from classic ember builds.
+    // This is here so it's *always* the real filename.
     filename: state.filename,
 
     plugins: {


### PR DESCRIPTION
with template tag syntax moduleName no longer has an accurate representation related to a file

removing this and making consumers rely on call site invocation name is a better strategy going forward