### PR TITLE
Add's URL to allowed globals list

### DIFF
--- a/src/scope-locals.ts
+++ b/src/scope-locals.ts
@@ -46,6 +46,7 @@ export const ALLOWED_GLOBALS = new Set([
   //   WHATWG
   'localStorage',
   'sessionStorage',
+  'URL',
   // ////////////////
   // functions / utilities
   // ////////////////


### PR DESCRIPTION
The URL class has several static methods that can be useful to access from a template.

An example use case is
```hbs
<img src={{URL.createObjectURL file}} />
```

The only test I found for allowed globals is this https://github.com/emberjs/babel-plugin-ember-template-compilation/blob/3ca974ef4036a46a05563303727536c6ca66a056/__tests__/tests.ts#L1971
Looking at that I'm not sure how something like JSON.stringify is tested since it seems to just ensure if it's in the list it will be allowed, so I don't have any tests to go along with this keeping inline with how they are currently tested.

The URL spec is here https://url.spec.whatwg.org/#url
But two extra static methods are from the file api https://w3c.github.io/FileAPI/#dfn-createObjectURL