### PR TITLE
[backport 3.x] Fix template compiler deprecation in Ember 6.8 betas

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -38,23 +38,17 @@ jobs:
           cache: 'pnpm'
       - run: pnpm install
       - run: pnpm test
+      # For the Try Scenarios
+      - id: set-matrix
+        run: |
+          echo "matrix=$(pnpm -s dlx @embroider/try list)" >> $GITHUB_OUTPUT
 
   floating-test:
     name: Floating dependencies
+    needs: 'test'
     strategy:
       fail-fast: false
-      matrix:
-        node: ['18', '20', '22']
-        ember: ['~3.28.0', '~4.12.0', '~5.12.0', '~6.4.0', 'latest', 'beta']
-        os: ['ubuntu-latest']
-        include:
-          - node: 22
-            ember: '~6.4.0'
-            os: windows-latest
-          - node: 22
-            ember: latest
-            os: windows-latest
-
+      matrix: ${{fromJson(needs.test.outputs.matrix)}}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -63,7 +57,6 @@ jobs:
         with:
           cache: 'pnpm'
           node-version: ${{ matrix.node }}
-      - name: Set ember version
-        run: node ./scripts/set-ember-version.mjs ${{ matrix.ember }}
+      - run: pnpm dlx @embroider/try apply ${{ matrix.name }}
       - run: pnpm install --no-lockfile
       - run: pnpm test

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -61,3 +61,4 @@ jobs:
       - run: pnpm dlx @embroider/try apply ${{ matrix.name }}
       - run: pnpm install --no-lockfile
       - run: pnpm test
+        env: ${{ matrix.env }}

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -45,8 +45,16 @@ jobs:
       fail-fast: false
       matrix:
         node: ['18', '20', '22']
-        ember: ['~6.9.0', '6.10.0-beta.1']
-        os: ['ubuntu-latest', 'windows-latest']
+        ember: ['~3.28.0', '~4.12.0', '~5.12.0', '~6.4.0', 'latest', 'beta']
+        os: ['ubuntu-latest']
+        include:
+          - node: 22
+            ember: '~6.4.0'
+            os: windows-latest
+          - node: 22
+            ember: latest
+            os: windows-latest
+
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -42,6 +42,7 @@ jobs:
   floating-test:
     name: Floating dependencies
     strategy:
+      fail-fast: false
       matrix:
         node: ['18', '20', '22']
         ember: ['~6.9.0', '6.10.0-beta.1']

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -44,6 +44,7 @@ jobs:
     strategy:
       matrix:
         node: ['18', '20', '22']
+        ember: ['~6.9.0', '6.10.0-beta.1']
         os: ['ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
     steps:
@@ -53,5 +54,7 @@ jobs:
         with:
           cache: 'pnpm'
           node-version: ${{ matrix.node }}
+      - name: Set ember version
+        run: node ./scripts/set-ember-version.mjs ${{ matrix.ember }}
       - run: pnpm install --no-lockfile
       - run: pnpm test

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -29,7 +29,8 @@ jobs:
   test:
     name: Tests
     runs-on: ubuntu-latest
-
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/.try.mjs
+++ b/.try.mjs
@@ -1,18 +1,3 @@
-/*
-      matrix: 
-        node: ['18', '20', '22']
-        ember: ['~3.28.0', '~4.12.0', '~5.12.0', '~6.4.0', 'latest', 'beta']
-        os: ['ubuntu-latest']
-        include:
-          - node: 22
-            ember: '~6.4.0'
-            os: windows-latest
-          - node: 22
-            ember: latest
-            os: windows-latest
-
-*/
-
 const embers = [
   {
     name: 'ember-lts-3.28',

--- a/.try.mjs
+++ b/.try.mjs
@@ -1,0 +1,111 @@
+/*
+      matrix: 
+        node: ['18', '20', '22']
+        ember: ['~3.28.0', '~4.12.0', '~5.12.0', '~6.4.0', 'latest', 'beta']
+        os: ['ubuntu-latest']
+        include:
+          - node: 22
+            ember: '~6.4.0'
+            os: windows-latest
+          - node: 22
+            ember: latest
+            os: windows-latest
+
+*/
+
+const embers = [
+  {
+    name: 'ember-lts-3.28',
+    npm: {
+      devDependencies: {
+        'ember-source': '~3.28.0',
+      },
+    },
+    env: {
+      NO_LEXICAL_THIS: true,
+    },
+  },
+  {
+    name: 'ember-lts-4.12',
+    npm: {
+      devDependencies: {
+        'ember-source': '~4.12.0',
+      },
+    },
+    env: {
+      NO_LEXICAL_THIS: true,
+    },
+  },
+  {
+    name: 'ember-lts-5.12',
+    npm: {
+      devDependencies: {
+        'ember-source': '~5.12.0',
+      },
+    },
+    env: {
+      NO_LEXICAL_THIS: true,
+    },
+  },
+  {
+    name: 'ember-lts-6.4',
+    npm: {
+      devDependencies: {
+        'ember-source': 'npm:ember-source@~6.4.0',
+      },
+    },
+  },
+  {
+    name: 'ember-latest',
+    npm: {
+      devDependencies: {
+        'ember-source': 'npm:ember-source@latest',
+      },
+    },
+  },
+  {
+    name: 'ember-beta',
+    npm: {
+      devDependencies: {
+        'ember-source': 'npm:ember-source@beta',
+      },
+    },
+  },
+];
+
+const nodes = ['18', '20', '22'];
+
+const scenarios = nodes.flatMap((node) =>
+  embers.map((s) => ({
+    ...s,
+    node,
+    name: s.name + `-node-${node}`,
+    os: 'ubuntu-latest',
+  }))
+);
+
+/* Windows spot checks */
+scenarios.push({
+  name: 'ember-latest-windows',
+  os: 'windows-latest',
+  node: '22',
+  npm: {
+    devDependencies: {
+      'ember-source': 'npm:ember-source@latest',
+    },
+  },
+});
+scenarios.push({
+  name: 'ember-lts-6.4-windows',
+  os: 'windows-latest',
+  node: '22',
+  npm: {
+    devDependencies: {
+      'ember-source': 'npm:ember-source@~6.4.0',
+    },
+  },
+});
+
+export default {
+  scenarios,
+};

--- a/__tests__/all.test.ts
+++ b/__tests__/all.test.ts
@@ -2067,27 +2067,29 @@ describe('htmlbars-inline-precompile', function () {
       }
     );
 
-    it('captures lexical "this" in Element when template is used as an expression', async function () {
-      plugins = [
-        [
-          HTMLBarsInlinePrecompile,
-          {
-            targetFormat: 'hbs',
-          },
-        ],
-      ];
+    it.skipIf(noLexicalThis)(
+      'captures lexical "this" in Element when template is used as an expression',
+      async function () {
+        plugins = [
+          [
+            HTMLBarsInlinePrecompile,
+            {
+              targetFormat: 'hbs',
+            },
+          ],
+        ];
 
-      let transformed = await transform(
-        `import { template } from '@ember/template-compiler'; 
+        let transformed = await transform(
+          `import { template } from '@ember/template-compiler'; 
         import SomeComponent from './elsewhere.js';
         export function exampleTest() {
           this.message = SomeComponent;
           render(template('<this.message />', { eval: function() { return eval(arguments[0]) } }))
         }
         `
-      );
+        );
 
-      expect(transformed).equalCode(`
+        expect(transformed).equalCode(`
         import SomeComponent from './elsewhere.js';
         import { precompileTemplate } from "@ember/template-compilation";
         import { setComponentTemplate } from "@ember/component";
@@ -2107,7 +2109,8 @@ describe('htmlbars-inline-precompile', function () {
           );
         }
       `);
-    });
+      }
+    );
 
     it('does not captures lexical "this" when template is used in class body', async function () {
       plugins = [
@@ -2412,7 +2415,7 @@ describe('htmlbars-inline-precompile', function () {
         `);
     });
 
-    it('expression form can capture lexical "this"', async function () {
+    it.skipIf(noLexicalThis)('expression form can capture lexical "this"', async function () {
       plugins = [
         [
           HTMLBarsInlinePrecompile,

--- a/__tests__/all.test.ts
+++ b/__tests__/all.test.ts
@@ -1878,7 +1878,7 @@ describe('htmlbars-inline-precompile', function () {
       expect(precompileSpy.mock.lastCall?.at(-1)).toHaveProperty('locals', ['bar']);
     });
 
-    it('can pass lexically scoped "this"', async function () {
+    it.skipIf(noLexicalThis)('can pass lexically scoped "this"', async function () {
       let transformed = await transform(`
         import { precompileTemplate } from '@ember/template-compilation';
         export function example() {

--- a/__tests__/all.test.ts
+++ b/__tests__/all.test.ts
@@ -386,7 +386,7 @@ describe('htmlbars-inline-precompile', function () {
           */
           {
             id: "<id>",
-            block: "[[[8,[32,0],null,null,null]],[],[]]",
+            block: "<block>",
             moduleName: "<moduleName>",
             scope: () => [Setup],
             isStrictMode: true,
@@ -813,7 +813,7 @@ describe('htmlbars-inline-precompile', function () {
        */
       {
         id: "<id>",
-        block: '[[[8,[39,0],null,[["@text"],[[32,0]]],null]],[],["message"]]',
+        block: "<block>",
         moduleName: "<moduleName>",
         scope: () => [two],
         isStrictMode: false,
@@ -1705,7 +1705,7 @@ describe('htmlbars-inline-precompile', function () {
       */
         {
           id: "<id>",
-          block: "[[[8,[32,0],null,null,null]],[],[]]",
+          block: "<block>",
           moduleName: "<moduleName>",
           scope: () => [HelloWorld],
           isStrictMode: true,
@@ -1750,7 +1750,7 @@ describe('htmlbars-inline-precompile', function () {
           */
               {
                 id: "<id>",
-                block: "[[[8,[32,0],null,null,null]],[],[]]",
+                block: "<block>",
                 moduleName: "<moduleName>",
                 scope: () => [HelloWorld],
                 isStrictMode: true,
@@ -1829,7 +1829,7 @@ describe('htmlbars-inline-precompile', function () {
           */
           {
             id: "<id>",
-            block: "[[[8,[32,0],null,null,null],[8,[32,1],null,null,null]],[],[]]",
+            block: "<block>",
             moduleName: "<moduleName>",
             scope: () => [bar, MyButton],
             isStrictMode: false,
@@ -1893,7 +1893,7 @@ describe('htmlbars-inline-precompile', function () {
             */
             {
               id: "<id>",
-              block: '[[[1,[32,0,["message"]]]],[],[]]',
+              block: "<block>",
               moduleName: "<moduleName>",
               scope: () => [this],
               isStrictMode: false,
@@ -2255,7 +2255,7 @@ describe('htmlbars-inline-precompile', function () {
             */
             {
               id: "<id>",
-              block: "[[[8,[32,0],null,null,null]],[],[]]",
+              block: "<block>",
               moduleName: "<moduleName>",
               scope: () => [HelloWorld],
               isStrictMode: true,
@@ -2365,7 +2365,7 @@ describe('htmlbars-inline-precompile', function () {
        */
         {
           id: "<id>",
-          block: "[[[8,[32,0],null,null,null]],[],[]]",
+          block: "<block>",
           moduleName: "<moduleName>",
           scope: () => [HelloWorld],
           isStrictMode: true,
@@ -2517,5 +2517,6 @@ function normalizeWireFormat(src: string): string {
   return src
     .replace(/"moduleName":\s"[^"]+"/, '"moduleName": "<moduleName>"')
     .replace(/"id":\s"[^"]+"/, '"id": "<id>"')
-    .replace(`"id": null`, '"id": "<id>"');
+    .replace(`"id": null`, '"id": "<id>"')
+    .replace(/"block":.+,\n/, '"block": "<block>",');
 }

--- a/__tests__/all.test.ts
+++ b/__tests__/all.test.ts
@@ -1,3 +1,4 @@
+import './raise-on-deprecated-template-compiler.js';
 import path from 'path';
 import * as babel from '@babel/core';
 import HTMLBarsInlinePrecompile, { Options } from '../src/node-main.js';
@@ -14,18 +15,14 @@ import { Preprocessor } from 'content-tag';
 import { ALLOWED_GLOBALS } from '../src/scope-locals.js';
 import { fileURLToPath } from 'url';
 import { describe, it, beforeEach, afterEach, expect, chai } from 'vitest';
-import { codeEquality } from 'code-equality-assertions/chai';
+import { codeEquality, type CodeEqualityAssertions } from 'code-equality-assertions/chai';
 chai.use(codeEquality);
 
-// @ts-expect-error no upstream types
-import * as _compiler from 'ember-source/dist/ember-template-compiler.js';
-
-const compiler: EmberTemplateCompiler = _compiler.default;
+const compiler: EmberTemplateCompiler = // @ts-expect-error no upstream types
+  await import('ember-source/dist/ember-template-compiler.js');
 
 declare module 'vitest' {
-  interface Assertion {
-    equalCode(expectedCode: string, message?: string): void;
-  }
+  interface Assertion extends CodeEqualityAssertions {}
 }
 
 describe('htmlbars-inline-precompile', function () {

--- a/__tests__/all.test.ts
+++ b/__tests__/all.test.ts
@@ -24,12 +24,13 @@ let precompileSpy: Mock;
 
 async function mockTemplateCompiler(importOriginal: () => Promise<EmberTemplateCompiler>) {
   const mod = await importOriginal();
-  precompileSpy = vi.spyOn(mod, 'precompile');
+  precompileSpy = vi.fn(mod.precompile);
   return {
     // the plugin probes for the existence of this, and if we don't stick a key
     // here Vitest injects a failure
     default: null,
     ...mod,
+    precompile: precompileSpy,
   };
 }
 

--- a/__tests__/raise-on-deprecated-template-compiler.ts
+++ b/__tests__/raise-on-deprecated-template-compiler.ts
@@ -1,0 +1,8 @@
+const orig = console.log;
+console.log = function (message, ...rest) {
+  orig.call(this, `customized console.log for ${message}`);
+  if (message.includes('Your app is using the legacy ember-template-compiler.js AMD bundle')) {
+    throw new Error(`We tried to use the deprecated ember-template-compiler.js`);
+  }
+  return orig.call(this, message, ...rest);
+};

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test": "vitest --dir __tests__"
   },
   "dependencies": {
+    "@glimmer/env": "^0.1.7",
     "@glimmer/syntax": ">= 0.94.9",
     "babel-import-util": "^3.0.0",
     "import-meta-resolve": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@types/babel__core": "^7.20.1",
     "@types/babel__traverse": "^7.11.1",
     "@types/node": "^20.5.7",
-    "@types/sinon": "^10.0.13",
     "@typescript-eslint/eslint-plugin": "^7.14.1",
     "@typescript-eslint/parser": "^7.14.1",
     "code-equality-assertions": "^1.0.1",
@@ -58,7 +57,6 @@
     "release-it": "^14.10.0",
     "release-it-lerna-changelog": "^3.1.0",
     "release-plan": "^0.16.0",
-    "sinon": "^14.0.0",
     "typescript": "^5.8.2",
     "vitest": "^4.0.15"
   },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "test": "vitest --dir __tests__"
   },
   "dependencies": {
-    "@glimmer/env": "^0.1.7",
     "@glimmer/syntax": ">= 0.94.9",
     "babel-import-util": "^3.0.0",
     "import-meta-resolve": "^4.1.0"
@@ -40,6 +39,7 @@
     "@babel/plugin-transform-typescript": "^7.22.11",
     "@babel/plugin-transform-unicode-escapes": "^7.14.5",
     "@babel/traverse": "^7.14.5",
+    "@glimmer/env": "^0.1.7",
     "@types/babel__core": "^7.20.1",
     "@types/babel__traverse": "^7.11.1",
     "@types/node": "^20.5.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@glimmer/env':
-        specifier: ^0.1.7
-        version: 0.1.7
       '@glimmer/syntax':
         specifier: '>= 0.94.9'
         version: 0.94.9
@@ -42,6 +39,9 @@ importers:
       '@babel/traverse':
         specifier: ^7.14.5
         version: 7.27.0
+      '@glimmer/env':
+        specifier: ^0.1.7
+        version: 0.1.7
       '@types/babel__core':
         specifier: ^7.20.1
         version: 7.20.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,9 +48,6 @@ importers:
       '@types/node':
         specifier: ^20.5.7
         version: 20.17.27
-      '@types/sinon':
-        specifier: ^10.0.13
-        version: 10.0.20
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.14.1
         version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2)
@@ -96,9 +93,6 @@ importers:
       release-plan:
         specifier: ^0.16.0
         version: 0.16.0
-      sinon:
-        specifier: ^14.0.0
-        version: 14.0.2
       typescript:
         specifier: ^5.8.2
         version: 5.8.2
@@ -1239,27 +1233,6 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
-  '@sinonjs/commons@1.8.6':
-    resolution: {integrity: sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==}
-
-  '@sinonjs/commons@2.0.0':
-    resolution: {integrity: sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==}
-
-  '@sinonjs/commons@3.0.1':
-    resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
-
-  '@sinonjs/fake-timers@11.3.1':
-    resolution: {integrity: sha512-EVJO7nW5M/F5Tur0Rf2z/QoMo+1Ia963RiMtapiQrEWvY0iBUvADo8Beegwjpnle5BHkyHuoxSTW3jF43H1XRA==}
-
-  '@sinonjs/fake-timers@9.1.2':
-    resolution: {integrity: sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==}
-
-  '@sinonjs/samsam@7.0.1':
-    resolution: {integrity: sha512-zsAk2Jkiq89mhZovB2LLOdTCxJF4hqqTToGP0ASWlhp4I1hqOjcfmZGafXntCN7MDC6yySH0mFHrYtHceOeLmw==}
-
-  '@sinonjs/text-encoding@0.7.3':
-    resolution: {integrity: sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==}
-
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
@@ -1309,12 +1282,6 @@ packages:
 
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
-
-  '@types/sinon@10.0.20':
-    resolution: {integrity: sha512-2APKKruFNCAZgx3daAyACGzWuJ028VVCUDk6o2rw/Z4PXT0ogwdV4KUegW0MwVs0Zu59auPXbbuBJHF12Sx1Eg==}
-
-  '@types/sinonjs__fake-timers@8.1.5':
-    resolution: {integrity: sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==}
 
   '@types/symlink-or-copy@1.2.2':
     resolution: {integrity: sha512-MQ1AnmTLOncwEf9IVU+B2e4Hchrku5N67NkgcAHW0p3sdzPe0FNMANxEm6OJUzPniEQGkeT3OROLlCwZJLWFZA==}
@@ -3054,9 +3021,6 @@ packages:
   jsonify@0.0.1:
     resolution: {integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==}
 
-  just-extend@6.2.0:
-    resolution: {integrity: sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==}
-
   keyv@3.1.0:
     resolution: {integrity: sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==}
 
@@ -3101,10 +3065,6 @@ packages:
 
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
-
-  lodash.get@4.4.2:
-    resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
-    deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -3311,9 +3271,6 @@ packages:
 
   nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
-
-  nise@5.1.9:
-    resolution: {integrity: sha512-qOnoujW4SV6e40dYxJOb3uvuoPHtmLzIk4TFo+j0jPJoC+5Z9xja5qH5JZobEPsa8+YYphMrOSwnrshEhG2qww==}
 
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
@@ -3554,9 +3511,6 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
-
-  path-to-regexp@6.3.0:
-    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -4019,10 +3973,6 @@ packages:
   simple-html-tokenizer@0.5.11:
     resolution: {integrity: sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==}
 
-  sinon@14.0.2:
-    resolution: {integrity: sha512-PDpV0ZI3ZCS3pEqx0vpNp6kzPhHrLx72wA0G+ZLaaJjLIYeE0n8INlgaohKuGy7hP0as5tbUd23QWu5U233t+w==}
-    deprecated: 16.1.1
-
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -4278,14 +4228,6 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
-
-  type-detect@4.0.8:
-    resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
-    engines: {node: '>=4'}
-
-  type-detect@4.1.0:
-    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
-    engines: {node: '>=4'}
 
   type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
@@ -5971,34 +5913,6 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
-  '@sinonjs/commons@1.8.6':
-    dependencies:
-      type-detect: 4.0.8
-
-  '@sinonjs/commons@2.0.0':
-    dependencies:
-      type-detect: 4.0.8
-
-  '@sinonjs/commons@3.0.1':
-    dependencies:
-      type-detect: 4.0.8
-
-  '@sinonjs/fake-timers@11.3.1':
-    dependencies:
-      '@sinonjs/commons': 3.0.1
-
-  '@sinonjs/fake-timers@9.1.2':
-    dependencies:
-      '@sinonjs/commons': 1.8.6
-
-  '@sinonjs/samsam@7.0.1':
-    dependencies:
-      '@sinonjs/commons': 2.0.0
-      lodash.get: 4.4.2
-      type-detect: 4.1.0
-
-  '@sinonjs/text-encoding@0.7.3': {}
-
   '@standard-schema/spec@1.0.0': {}
 
   '@szmarczak/http-timer@1.1.2':
@@ -6056,12 +5970,6 @@ snapshots:
   '@types/responselike@1.0.3':
     dependencies:
       '@types/node': 20.17.27
-
-  '@types/sinon@10.0.20':
-    dependencies:
-      '@types/sinonjs__fake-timers': 8.1.5
-
-  '@types/sinonjs__fake-timers@8.1.5': {}
 
   '@types/symlink-or-copy@1.2.2': {}
 
@@ -8203,8 +8111,6 @@ snapshots:
 
   jsonify@0.0.1: {}
 
-  just-extend@6.2.0: {}
-
   keyv@3.1.0:
     dependencies:
       json-buffer: 3.0.0
@@ -8259,8 +8165,6 @@ snapshots:
       p-locate: 5.0.0
 
   lodash.debounce@4.0.8: {}
-
-  lodash.get@4.4.2: {}
 
   lodash.merge@4.6.2: {}
 
@@ -8491,14 +8395,6 @@ snapshots:
       type-fest: 0.4.1
 
   nice-try@1.0.5: {}
-
-  nise@5.1.9:
-    dependencies:
-      '@sinonjs/commons': 3.0.1
-      '@sinonjs/fake-timers': 11.3.1
-      '@sinonjs/text-encoding': 0.7.3
-      just-extend: 6.2.0
-      path-to-regexp: 6.3.0
 
   node-fetch@2.7.0(encoding@0.1.13):
     dependencies:
@@ -8760,8 +8656,6 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
       minipass: 7.1.2
-
-  path-to-regexp@6.3.0: {}
 
   path-type@4.0.0: {}
 
@@ -9319,15 +9213,6 @@ snapshots:
 
   simple-html-tokenizer@0.5.11: {}
 
-  sinon@14.0.2:
-    dependencies:
-      '@sinonjs/commons': 2.0.0
-      '@sinonjs/fake-timers': 9.1.2
-      '@sinonjs/samsam': 7.0.1
-      diff: 5.2.0
-      nise: 5.1.9
-      supports-color: 7.2.0
-
   slash@3.0.0: {}
 
   smart-buffer@4.2.0: {}
@@ -9586,10 +9471,6 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
-
-  type-detect@4.0.8: {}
-
-  type-detect@4.1.0: {}
 
   type-fest@0.20.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@glimmer/env':
+        specifier: ^0.1.7
+        version: 0.1.7
       '@glimmer/syntax':
         specifier: '>= 0.94.9'
         version: 0.94.9

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,7 +59,7 @@ importers:
         version: 7.18.0(eslint@8.57.1)(typescript@5.8.2)
       code-equality-assertions:
         specifier: ^1.0.1
-        version: 1.0.1
+        version: 1.1.0
       common-tags:
         specifier: ^1.8.0
         version: 1.8.2
@@ -71,7 +71,7 @@ importers:
         version: 7.0.3
       ember-source:
         specifier: ^6.4.0-beta.1
-        version: 6.4.0-beta.2(rsvp@4.8.5)
+        version: 6.9.0(rsvp@4.8.5)
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
@@ -844,8 +844,8 @@ packages:
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
 
-  '@glimmer/compiler@0.94.10':
-    resolution: {integrity: sha512-SrWiaKM3AND2FQ732wtjAKol7XhCnRqit3tJShG4X0mT27Jb3zuhTI2dkfYVVMTJ23pjT/+0y+s/uGaBSirnBg==}
+  '@glimmer/compiler@0.94.11':
+    resolution: {integrity: sha512-t9eyLZIFsiwAib8Zyfu67yBep5Vn2bd5DScIE2hharPE/OKKI7cpQYi6BzQhSGYEBVU82ITd/2TLvJ1K8eIahA==}
     engines: {node: '>= 18.0.0'}
 
   '@glimmer/destroyable@0.94.8':
@@ -863,38 +863,41 @@ packages:
   '@glimmer/interfaces@0.94.6':
     resolution: {integrity: sha512-sp/1WePvB/8O+jrcUHwjboNPTKrdGicuHKA9T/lh0vkYK2qM5Xz4i25lQMQ38tEMiw7KixrjHiTUiaXRld+IwA==}
 
-  '@glimmer/manager@0.94.9':
-    resolution: {integrity: sha512-AQT90eSRbgx6O4VnyRgR+y3SqKChPrpZs5stENa0UnqOSbt7dF6XdqAmllfznKFpLlKmJSV7JaVpCarVTR/JQQ==}
+  '@glimmer/manager@0.94.10':
+    resolution: {integrity: sha512-Hqi92t6vtVg4nSRGWTvCJ+0Vg3iF1tiTG9RLzuUtZac7DIAzuQAxjhGbtu82miT+liCqU+MFmB3nkfNH0Zz74g==}
 
-  '@glimmer/node@0.94.9':
-    resolution: {integrity: sha512-X90Xyru/TNi/ocq27ttT4zlMGK931J+pGL0eDYEkUX2fJYHd9Wm1idAB7MLJYIJarv/kuoxteiGThGIYkeNVaQ==}
+  '@glimmer/node@0.94.10':
+    resolution: {integrity: sha512-8kw6K+RoKhjfprMO059M7x5yRZRK7WGLzD2056/G+65wV7gnJVDuh4qQirekaagjtskz6OdRBVWrSmrbICWtzQ==}
 
-  '@glimmer/opcode-compiler@0.94.9':
-    resolution: {integrity: sha512-LlBniSmtBoIlkxzPKHyOw4Nj946Cczelo8RAnqoG/egkHuk4hoO/7ycSgNpPvV3G14BA4Fpy5ExBffx6iuRxQQ==}
+  '@glimmer/opcode-compiler@0.94.10':
+    resolution: {integrity: sha512-KYsaODjkgtpUzMR1chyI0IRcvo4ewnjW8Dy+5833+OIG7rx6INl7HvKtooLzjHv+uJOZ74fd/s/0XfaY6eNEww==}
 
   '@glimmer/owner@0.93.4':
     resolution: {integrity: sha512-xoclaVdCF4JH/yx8dHplCj6XFAa7ggwc7cyeOthRvTNGsp/J/CNKHT6NEkdERBYqy6tvg5GoONvWFdm8Wd5Uig==}
 
-  '@glimmer/program@0.94.9':
-    resolution: {integrity: sha512-KA3TXYL2iDdR92pPnB/sw1tgIC7B40l2P60iD1sqkYbyxAbrUPHSToA1ycmK4DwmxDOT3Hz9dvpceoCMbh0xjA==}
+  '@glimmer/program@0.94.10':
+    resolution: {integrity: sha512-a5rpsvBwrcAn0boV4ONy+dHr8tWSTvLAPTR1T1KxF0OBHRVciCAfBPRFemVO6Q3H117At9ifn3uoevtQ6H0M+Q==}
 
-  '@glimmer/reference@0.94.8':
-    resolution: {integrity: sha512-FPoXBRMXJupO9nAq/Vw3EY/FCY3xbd+VALqZupyu6ds9vjNiKAkD9+ujIjYa1f+d/ez2ONhy8QjEFoBsyW2flA==}
+  '@glimmer/reference@0.94.9':
+    resolution: {integrity: sha512-qlgTYxgEOpgxuyb13u2qwqhibpfktlk08F+nfwuNxtuhodsItBi3YxjFMPrVP0zOjTnhUObR8OYtMsD5WFOddA==}
 
-  '@glimmer/runtime@0.94.10':
-    resolution: {integrity: sha512-eRe9TmP02ESVXJn2ZOOEm/Hm/Ro7X0kRvZsU8OVtXOqWU8JxeKMwjCEiLbJBQKbYfycRy1u8jZ2wuH0qM/d3EQ==}
+  '@glimmer/runtime@0.94.11':
+    resolution: {integrity: sha512-96PqfxnkEW8k8dMydDmaXgijD7yvtIfjMkHoJ7ljUmE1icZ7jj6f+UIZ0LThpXMzkKaBe1xEapjr91Ldsvmqbg==}
 
   '@glimmer/syntax@0.94.9':
     resolution: {integrity: sha512-OBw8DqMzKO4LX4kJBhwfTUqtpbd7O9amQXNTfb1aS7pufio5Vu5Qi6mRTfdFj6RyJ//aSI/l0kxWt6beYW0Apg==}
 
+  '@glimmer/syntax@0.95.0':
+    resolution: {integrity: sha512-W/PHdODnpONsXjbbdY9nedgIHpglMfOzncf/moLVrKIcCfeQhw2vG07Rs/YW8KeJCgJRCLkQsi+Ix7XvrurGAg==}
+
   '@glimmer/util@0.94.8':
     resolution: {integrity: sha512-HfCKeZ74clF9BsPDBOqK/yRNa/ke6niXFPM6zRn9OVYw+ZAidLs7V8He/xljUHlLRL322kaZZY8XxRW7ALEwyg==}
 
-  '@glimmer/validator@0.94.8':
-    resolution: {integrity: sha512-vTP6hAcrxE5/0dG2w+tHSteXxgWmkBwMzu5ZTxMg+EkqthWl8B5r5skLiviQ6SdKAOBJGhzf6tF4ltHo5y83hQ==}
+  '@glimmer/validator@0.95.0':
+    resolution: {integrity: sha512-xF3K5voKeRqhONztfMHDd2wHDYD6UUI9pFPd+RMGtW6DXYv31G0zUm2pGsOwQ9dyNeE6khaXy7e3FtNjDrSmvQ==}
 
-  '@glimmer/vm-babel-plugins@0.93.4':
-    resolution: {integrity: sha512-+MjT+U/MsP7O32rXTYlvcmuiKtwI/PflokpVIW0M9wrkfFrsqgdhLQKvA+tNNxFW9LQ55zbhOtJweFNblHOvxg==}
+  '@glimmer/vm-babel-plugins@0.93.5':
+    resolution: {integrity: sha512-xwVRgDjuadOB9qV1jyTKBrUgE/cpmixD/wIYnFf4+hNJRD39urteKRPw98xJSAt7Bw/6y5B8zsgwFS18Nknlrg==}
     engines: {node: '>=18.18.0'}
 
   '@glimmer/vm@0.94.8':
@@ -905,6 +908,10 @@ packages:
 
   '@handlebars/parser@2.0.0':
     resolution: {integrity: sha512-EP9uEDZv/L5Qh9IWuMUGJRfwhXJ4h1dqKTT4/3+tY0eu7sPis7xh23j61SYUnNF4vqCQvvUXpDo9Bh/+q1zASA==}
+
+  '@handlebars/parser@2.2.2':
+    resolution: {integrity: sha512-n/SZW+12rwikx/f8YcSv9JCi5p9vn1Bnts9ZtVvfErG4h0gbjHI1H1ZMhVUnaOC7yzFc6PtsCKIK8XeTnL90Gw==}
+    engines: {node: ^18 || ^20 || ^22 || >=24}
 
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
@@ -1828,8 +1835,8 @@ packages:
     resolution: {integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==}
     engines: {node: '>=0.8'}
 
-  code-equality-assertions@1.0.1:
-    resolution: {integrity: sha512-QVoPdv5s17cGlCy2gd2Z0D9PXIYJd3VYilOK+6iTomzoel7xNUiIZOYYRNe3LbEncK0wuSJ9tvVByhySHrpO9w==}
+  code-equality-assertions@1.1.0:
+    resolution: {integrity: sha512-EoGPlzdu6iiL5N9HCnXN+rrYu8gsvhZBr4zHr1MIs7qLLYo29WxuLX+9tFDYAobLH82TWg8J4Ek/YiZXUvfq2g==}
     peerDependencies:
       '@types/jest': '2'
       '@types/qunit': '2'
@@ -2075,8 +2082,8 @@ packages:
     resolution: {integrity: sha512-89oVHVJwmLDvGvAUWgS87KpBoRhy3aZ6U0Ql6HOmU4TrPkyaa8pM0W81wj9cIwjYprcQtN9EwzZMHnq46+oUyw==}
     engines: {node: 8.* || 10.* || >= 12}
 
-  ember-source@6.4.0-beta.2:
-    resolution: {integrity: sha512-lqH22QIPKOPCC5xuhoUR7/DooS1hKt73VjNe9QNi3euOWgwRcX+jgOu1y36xc9hj36oHlZ6SRIuphq4fnVIJRw==}
+  ember-source@6.9.0:
+    resolution: {integrity: sha512-d/P2/z5Y82/EEn95JRkwYy/JckZTCAgfZZC3dhWWzzXt5ZGHbHbAhole0c4wuUyYz42thM6isJa3C97b/1PdcA==}
     engines: {node: '>= 18.*'}
     peerDependencies:
       '@glimmer/component': '>= 1.1.2'
@@ -5500,10 +5507,10 @@ snapshots:
 
   '@gar/promisify@1.1.3': {}
 
-  '@glimmer/compiler@0.94.10':
+  '@glimmer/compiler@0.94.11':
     dependencies:
       '@glimmer/interfaces': 0.94.6
-      '@glimmer/syntax': 0.94.9
+      '@glimmer/syntax': 0.95.0
       '@glimmer/util': 0.94.8
       '@glimmer/wire-format': 0.94.8
 
@@ -5526,61 +5533,61 @@ snapshots:
       '@simple-dom/interface': 1.4.0
       type-fest: 4.38.0
 
-  '@glimmer/manager@0.94.9':
+  '@glimmer/manager@0.94.10':
     dependencies:
       '@glimmer/destroyable': 0.94.8
       '@glimmer/global-context': 0.93.4
       '@glimmer/interfaces': 0.94.6
-      '@glimmer/reference': 0.94.8
+      '@glimmer/reference': 0.94.9
       '@glimmer/util': 0.94.8
-      '@glimmer/validator': 0.94.8
+      '@glimmer/validator': 0.95.0
       '@glimmer/vm': 0.94.8
 
-  '@glimmer/node@0.94.9':
+  '@glimmer/node@0.94.10':
     dependencies:
       '@glimmer/interfaces': 0.94.6
-      '@glimmer/runtime': 0.94.10
+      '@glimmer/runtime': 0.94.11
       '@glimmer/util': 0.94.8
       '@simple-dom/document': 1.4.0
 
-  '@glimmer/opcode-compiler@0.94.9':
+  '@glimmer/opcode-compiler@0.94.10':
     dependencies:
       '@glimmer/encoder': 0.93.8
       '@glimmer/interfaces': 0.94.6
-      '@glimmer/manager': 0.94.9
+      '@glimmer/manager': 0.94.10
       '@glimmer/util': 0.94.8
       '@glimmer/vm': 0.94.8
       '@glimmer/wire-format': 0.94.8
 
   '@glimmer/owner@0.93.4': {}
 
-  '@glimmer/program@0.94.9':
+  '@glimmer/program@0.94.10':
     dependencies:
       '@glimmer/interfaces': 0.94.6
-      '@glimmer/manager': 0.94.9
-      '@glimmer/opcode-compiler': 0.94.9
+      '@glimmer/manager': 0.94.10
+      '@glimmer/opcode-compiler': 0.94.10
       '@glimmer/util': 0.94.8
       '@glimmer/vm': 0.94.8
       '@glimmer/wire-format': 0.94.8
 
-  '@glimmer/reference@0.94.8':
+  '@glimmer/reference@0.94.9':
     dependencies:
       '@glimmer/global-context': 0.93.4
       '@glimmer/interfaces': 0.94.6
       '@glimmer/util': 0.94.8
-      '@glimmer/validator': 0.94.8
+      '@glimmer/validator': 0.95.0
 
-  '@glimmer/runtime@0.94.10':
+  '@glimmer/runtime@0.94.11':
     dependencies:
       '@glimmer/destroyable': 0.94.8
       '@glimmer/global-context': 0.93.4
       '@glimmer/interfaces': 0.94.6
-      '@glimmer/manager': 0.94.9
+      '@glimmer/manager': 0.94.10
       '@glimmer/owner': 0.93.4
-      '@glimmer/program': 0.94.9
-      '@glimmer/reference': 0.94.8
+      '@glimmer/program': 0.94.10
+      '@glimmer/reference': 0.94.9
       '@glimmer/util': 0.94.8
-      '@glimmer/validator': 0.94.8
+      '@glimmer/validator': 0.95.0
       '@glimmer/vm': 0.94.8
 
   '@glimmer/syntax@0.94.9':
@@ -5591,16 +5598,24 @@ snapshots:
       '@handlebars/parser': 2.0.0
       simple-html-tokenizer: 0.5.11
 
+  '@glimmer/syntax@0.95.0':
+    dependencies:
+      '@glimmer/interfaces': 0.94.6
+      '@glimmer/util': 0.94.8
+      '@glimmer/wire-format': 0.94.8
+      '@handlebars/parser': 2.2.2
+      simple-html-tokenizer: 0.5.11
+
   '@glimmer/util@0.94.8':
     dependencies:
       '@glimmer/interfaces': 0.94.6
 
-  '@glimmer/validator@0.94.8':
+  '@glimmer/validator@0.95.0':
     dependencies:
       '@glimmer/global-context': 0.93.4
       '@glimmer/interfaces': 0.94.6
 
-  '@glimmer/vm-babel-plugins@0.93.4(@babel/core@7.26.10)':
+  '@glimmer/vm-babel-plugins@0.93.5(@babel/core@7.26.10)':
     dependencies:
       babel-plugin-debug-macros: 0.3.4(@babel/core@7.26.10)
     transitivePeerDependencies:
@@ -5615,6 +5630,8 @@ snapshots:
       '@glimmer/interfaces': 0.94.6
 
   '@handlebars/parser@2.0.0': {}
+
+  '@handlebars/parser@2.2.2': {}
 
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
@@ -6705,7 +6722,7 @@ snapshots:
 
   clone@2.1.2: {}
 
-  code-equality-assertions@1.0.1:
+  code-equality-assertions@1.1.0:
     dependencies:
       '@babel/core': 7.26.10
       '@babel/plugin-syntax-typescript': 7.25.9(@babel/core@7.26.10)
@@ -6977,27 +6994,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-source@6.4.0-beta.2(rsvp@4.8.5):
+  ember-source@6.9.0(rsvp@4.8.5):
     dependencies:
       '@babel/core': 7.26.10
       '@ember/edition-utils': 1.2.0
       '@embroider/addon-shim': 1.9.0
-      '@glimmer/compiler': 0.94.10
+      '@glimmer/compiler': 0.94.11
       '@glimmer/destroyable': 0.94.8
       '@glimmer/global-context': 0.93.4
       '@glimmer/interfaces': 0.94.6
-      '@glimmer/manager': 0.94.9
-      '@glimmer/node': 0.94.9
-      '@glimmer/opcode-compiler': 0.94.9
+      '@glimmer/manager': 0.94.10
+      '@glimmer/node': 0.94.10
+      '@glimmer/opcode-compiler': 0.94.10
       '@glimmer/owner': 0.93.4
-      '@glimmer/program': 0.94.9
-      '@glimmer/reference': 0.94.8
-      '@glimmer/runtime': 0.94.10
-      '@glimmer/syntax': 0.94.9
+      '@glimmer/program': 0.94.10
+      '@glimmer/reference': 0.94.9
+      '@glimmer/runtime': 0.94.11
+      '@glimmer/syntax': 0.95.0
       '@glimmer/util': 0.94.8
-      '@glimmer/validator': 0.94.8
+      '@glimmer/validator': 0.95.0
       '@glimmer/vm': 0.94.8
-      '@glimmer/vm-babel-plugins': 0.93.4(@babel/core@7.26.10)
+      '@glimmer/vm-babel-plugins': 0.93.5(@babel/core@7.26.10)
       '@simple-dom/interface': 1.4.0
       backburner.js: 2.8.0
       broccoli-file-creator: 2.1.1

--- a/scripts/set-ember-version.mjs
+++ b/scripts/set-ember-version.mjs
@@ -1,0 +1,4 @@
+import fs from 'node:fs';
+let pkg = JSON.parse(fs.readFileSync('package.json'));
+pkg.devDependencies['ember-source'] = process.argv[2];
+fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2));

--- a/scripts/set-ember-version.mjs
+++ b/scripts/set-ember-version.mjs
@@ -1,4 +1,0 @@
-import fs from 'node:fs';
-let pkg = JSON.parse(fs.readFileSync('package.json'));
-pkg.devDependencies['ember-source'] = process.argv[2];
-fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2));

--- a/src/node-main.ts
+++ b/src/node-main.ts
@@ -57,7 +57,17 @@ async function handleNodeSpecificOptions(opts: Options): Promise<SharedOptions> 
     assertTemplateCompiler(opts.compiler);
     compiler = opts.compiler;
   } else if ((opts.targetFormat ?? 'wire') === 'wire') {
-    let mod: any = await cwdImport('ember-source/dist/ember-template-compiler.js');
+    let mod: any;
+    try {
+      // the newer path
+      mod = await cwdImport('ember-source/ember-template-compiler/index.js');
+    } catch (err: any) {
+      if (err.code !== 'ERR_MODULE_NOT_FOUND') {
+        throw err;
+      }
+      // the deprecated path
+      mod = await cwdImport('ember-source/dist/ember-template-compiler.js');
+    }
     assertTemplateCompiler(mod);
     compiler = mod;
   }


### PR DESCRIPTION
This is a backport of https://github.com/emberjs/babel-plugin-ember-template-compilation/pull/106