### PR TITLE
Fix floating-dependency CI

### DIFF
--- a/__tests__/all.test.ts
+++ b/__tests__/all.test.ts
@@ -12,7 +12,8 @@ import { EmberTemplateCompiler } from '../src/ember-template-compiler.js';
 import { ExtendedPluginBuilder } from '../src/js-utils.js';
 import { Preprocessor } from 'content-tag';
 import { ALLOWED_GLOBALS } from '../src/scope-locals.js';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { resolve as importMetaResolve } from 'import-meta-resolve';
 import { describe, it, beforeEach, afterEach, expect, chai, vi, type Mock } from 'vitest';
 import { codeEquality, type CodeEqualityAssertions } from 'code-equality-assertions/chai';
 
@@ -34,8 +35,24 @@ async function mockTemplateCompiler(importOriginal: () => Promise<EmberTemplateC
   };
 }
 
-vi.mock('ember-source/ember-template-compiler/index.js', mockTemplateCompiler);
-vi.mock('ember-source/dist/ember-template-compiler.js', mockTemplateCompiler);
+// The plugin resolves the template compiler from the current working directory
+// with node's own resolution rules (see cwdImport in node-main.ts). A static
+// vi.mock on the bare specifier can land on a different file: ember-source 7
+// maps its subpaths through conditional exports, and Vitest resolves the
+// "development" condition while the plugin's import gets the "default" one. So
+// we mock the exact modules the plugin will import.
+for (const specifier of [
+  'ember-source/ember-template-compiler/index.js',
+  'ember-source/dist/ember-template-compiler.js',
+]) {
+  let target: string;
+  try {
+    target = importMetaResolve(specifier, pathToFileURL(process.cwd() + path.sep).href);
+  } catch {
+    continue;
+  }
+  vi.doMock(target, mockTemplateCompiler);
+}
 
 declare module 'vitest' {
   interface Assertion extends CodeEqualityAssertions {}
@@ -752,7 +769,7 @@ describe('htmlbars-inline-precompile', function () {
       import { precompileTemplate } from '@ember/template-compilation';
       const template = precompileTemplate('<Message @text={{onePlusOne}} />');
     `);
-    expect(transformed).toContain(`"scope": () => [two]`);
+    expect(normalizeWireFormat(transformed)).toContain(`"scope": () => [two]`);
   });
 
   it('allows AST transform to bind a JS import', async function () {
@@ -2523,9 +2540,49 @@ describe('htmlbars-inline-precompile', function () {
 // This takes out parts of ember's wire format that aren't our job and shouldn't
 // break our tests if they change.
 function normalizeWireFormat(src: string): string {
-  return src
+  return canonicalizeWireScope(src)
     .replace(/"moduleName":\s"[^"]+"/, '"moduleName": "<moduleName>"')
     .replace(/"id":\s"[^"]+"/, '"id": "<id>"')
     .replace(`"id": null`, '"id": "<id>"')
     .replace(/"block":.+,\n/, '"block": "<block>",');
+}
+
+// Ember 7's template compiler emits the wire-format scope as an object whose
+// values are consumed positionally (via Object.values) at runtime, where
+// earlier compilers emitted an array. Rewrite the object form to the array
+// form so our expected outputs are version-independent.
+function canonicalizeWireScope(src: string): string {
+  let sawObjectScope = false;
+  let result = babel.transformSync(src, {
+    configFile: false,
+    plugins: [
+      function canonicalScope({ types: t }: typeof babel): babel.PluginObj {
+        return {
+          visitor: {
+            ObjectProperty(path) {
+              let { key, value } = path.node;
+              let isScopeKey =
+                (t.isIdentifier(key) && key.name === 'scope') ||
+                (t.isStringLiteral(key) && key.value === 'scope');
+              if (
+                isScopeKey &&
+                t.isArrowFunctionExpression(value) &&
+                t.isObjectExpression(value.body)
+              ) {
+                sawObjectScope = true;
+                value.body = t.arrayExpression(
+                  value.body.properties.map(
+                    (prop) => (prop as babel.types.ObjectProperty).value as babel.types.Expression
+                  )
+                );
+              }
+            },
+          },
+        };
+      },
+    ],
+  });
+  // when there's nothing to rewrite, keep the input byte-for-byte so this
+  // helper stays inert on compiler versions that emit the array form
+  return sawObjectScope ? result!.code! : src;
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "release-it-lerna-changelog": "^3.1.0",
     "release-plan": "^0.16.0",
     "typescript": "^5.8.2",
-    "vitest": "^4.0.15"
+    "vitest": "~4.0.15"
   },
   "packageManager": "pnpm@9.0.6",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,7 +100,7 @@ importers:
         specifier: ^5.8.2
         version: 5.8.2
       vitest:
-        specifier: ^4.0.15
+        specifier: ~4.0.15
         version: 4.0.15(@types/node@20.17.27)(yaml@1.10.2)
 
 packages:
@@ -881,9 +881,6 @@ packages:
   '@glimmer/runtime@0.94.11':
     resolution: {integrity: sha512-96PqfxnkEW8k8dMydDmaXgijD7yvtIfjMkHoJ7ljUmE1icZ7jj6f+UIZ0LThpXMzkKaBe1xEapjr91Ldsvmqbg==}
 
-  '@glimmer/syntax@0.94.9':
-    resolution: {integrity: sha512-OBw8DqMzKO4LX4kJBhwfTUqtpbd7O9amQXNTfb1aS7pufio5Vu5Qi6mRTfdFj6RyJ//aSI/l0kxWt6beYW0Apg==}
-
   '@glimmer/syntax@0.95.0':
     resolution: {integrity: sha512-W/PHdODnpONsXjbbdY9nedgIHpglMfOzncf/moLVrKIcCfeQhw2vG07Rs/YW8KeJCgJRCLkQsi+Ix7XvrurGAg==}
 
@@ -902,9 +899,6 @@ packages:
 
   '@glimmer/wire-format@0.94.8':
     resolution: {integrity: sha512-A+Cp5m6vZMAEu0Kg/YwU2dJZXyYxVJs2zI57d3CP6NctmX7FsT8WjViiRUmt5abVmMmRH5b8BUovqY6GSMAdrw==}
-
-  '@handlebars/parser@2.0.0':
-    resolution: {integrity: sha512-EP9uEDZv/L5Qh9IWuMUGJRfwhXJ4h1dqKTT4/3+tY0eu7sPis7xh23j61SYUnNF4vqCQvvUXpDo9Bh/+q1zASA==}
 
   '@handlebars/parser@2.2.2':
     resolution: {integrity: sha512-n/SZW+12rwikx/f8YcSv9JCi5p9vn1Bnts9ZtVvfErG4h0gbjHI1H1ZMhVUnaOC7yzFc6PtsCKIK8XeTnL90Gw==}
@@ -1349,6 +1343,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitest/expect@4.0.15':
     resolution: {integrity: sha512-Gfyva9/GxPAWXIWjyGDli9O+waHDC0Q0jaLdFP1qPAUUfo1FEXPXUfUkp3eZA0sSq340vPycSyOlYUeM15Ft1w==}
@@ -2476,19 +2471,21 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@5.0.15:
     resolution: {integrity: sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@9.3.5:
     resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
     engines: {node: '>=16 || 14 >=14.17'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-dirs@3.0.1:
     resolution: {integrity: sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==}
@@ -4149,6 +4146,7 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
@@ -4361,6 +4359,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   validate-npm-package-license@3.0.4:
@@ -5532,14 +5531,6 @@ snapshots:
       '@glimmer/validator': 0.95.0
       '@glimmer/vm': 0.94.8
 
-  '@glimmer/syntax@0.94.9':
-    dependencies:
-      '@glimmer/interfaces': 0.94.6
-      '@glimmer/util': 0.94.8
-      '@glimmer/wire-format': 0.94.8
-      '@handlebars/parser': 2.0.0
-      simple-html-tokenizer: 0.5.11
-
   '@glimmer/syntax@0.95.0':
     dependencies:
       '@glimmer/interfaces': 0.94.6
@@ -5570,8 +5561,6 @@ snapshots:
   '@glimmer/wire-format@0.94.8':
     dependencies:
       '@glimmer/interfaces': 0.94.6
-
-  '@handlebars/parser@2.0.0': {}
 
   '@handlebars/parser@2.2.2': {}
 


### PR DESCRIPTION
All 20 floating-dependency scenarios have failed on the weekly schedule since 2026-03-15 (last green 2026-03-08), and the cron has since been suspended by GitHub for repo inactivity, hiding further drift. Two independent causes; expired CI logs meant reproducing each scenario locally.

## 1. vitest 4.1 can't start under this repo's toolchain

vitest 4.1.0 (published 2026-03-12, exactly in the green→red window) floated in via `^4.0.15`. It makes rolldown a hard dependency, which breaks the `pnpm install --no-lockfile` jobs on **every** node version:

- rolldown's native binding declares `libc: "glibc"`, and the pinned `pnpm@9.0.6` doesn't understand that field, so the binding is silently skipped → `Error: Cannot find native binding` at vitest startup (node 20/22 rows).
- rolldown also requires node ≥20.19 (`styleText` from `node:util`), so the node 18 rows die even earlier with a `SyntaxError`.

**Fix here:** pin `vitest` to `~4.0.15` (lockfile stays on 4.0.x; only the specifier changes). Floating to vitest 4.1+ would require dropping the node 18 scenarios *and* bumping pnpm — that's a support-matrix decision I didn't want to bundle into a CI repair; happy to do it as a follow-up if you'd rather go that way.

## 2. ember-source@latest/beta became 7.x during the outage

`ember-latest` / `ember-beta` scenarios now install ember-source 7.1.0 / 7.2.0-beta.1, which broke 32 tests in two ways — both test-harness issues, the plugin's actual output is fine:

- **The compiler mock stopped applying.** Ember 7 moved the template compiler behind conditional exports (`dist/dev/*` vs `dist/prod/*`). Vitest resolves the static `vi.mock` specifier with the `development` condition; the plugin's cwd-relative import (`cwdImport` in `node-main.ts`) resolves the `default` condition. Different files → `precompileSpy` never installed. The mock is now registered against the exact module the plugin resolves, using the same `import-meta-resolve` call the plugin uses.
- **The wire format changed shape.** Ember 7 emits `scope: () => ({ Setup })` where older compilers emit `scope: () => [Setup]`. The runtime consumes the object positionally (`Object.values(scopeRecord)` in glimmer-vm), so keys are cosmetic and the plugin's output is correct — only the expected outputs were stale. `normalizeWireFormat` now canonicalizes the object form back to the array form (and stays byte-for-byte inert on compilers that emit arrays).

## Verification

Ran each scenario locally via `@embroider/try apply` + `pnpm install --no-lockfile` + `pnpm test`, with pnpm 9.0.6 matching CI:

| scenario | ember-source | node | result |
|---|---|---|---|
| lockfile install (Tests job) | 6.4 | 18 | 127 passed |
| ember-lts-3.28 | 3.28.12 | 18 | 123 passed, 4 skipped |
| ember-lts-4.12 | 4.12.4 | 18 | 123 passed, 4 skipped |
| ember-lts-5.12 | 5.12.0 | 22 | 123 passed, 4 skipped |
| ember-lts-6.4 | 6.4.0 | 22 | 127 passed |
| ember-latest | 7.1.0 | 22 | 127 passed |
| ember-beta | 7.2.0-beta.1 | 22 | 127 passed |

(Skips are the pre-existing `NO_LEXICAL_THIS` guards those scenarios set.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)